### PR TITLE
feat(design): add "be your own bank"/branding

### DIFF
--- a/app/partials/top.jade
+++ b/app/partials/top.jade
@@ -1,22 +1,28 @@
 .flex-center.flex-between.height-100(ng-show="status.isLoggedIn")
-  .button-group.flex
-    a.flex-center.flex-justify.mrm(ng-click="request()")
-      i.bc-icon-receive
-      span(translate="REQUEST")
-    a.flex-center.flex-justify(ng-click="send()")
-      i.bc-icon-send
-      span(translate="SEND")
-  .balance.flex-column.flex-align-end.right-align.pointer(ng-click="toggleDisplayCurrency()", ng-show="status.didUpgradeToHd")
+  .flex-column
+    .flex-baseline.heavy
+      h1.mtn.my-wallet My Wallet
+      p.mtn.mlm.type-h4.em-300
+        | Be your own bank.
+        span.type-xs.mls.align-offset.pos-rel &reg;
+    .button-group.flex
+      a.em-300.flex-center.flex-justify.mrm(ng-click="request()")
+        i.bc-icon-receive
+        span(translate="REQUEST")
+      a.em-300.flex-center.flex-justify(ng-click="send()")
+        i.bc-icon-send
+        span(translate="SEND")
+  .heavy.pointer.flex-column.flex-align-end.right-align.pointer(ng-click="toggleDisplayCurrency()", ng-show="status.didUpgradeToHd")
     span(ng-show="getTotal(accountIndex) == null")
       h3
         img(ng-show="balance == null" src="img/spinner.gif") 
     span(ng-show="getTotal(accountIndex) != null")
       span(ng-hide="isBitCurrency(settings.displayCurrency)")
-        h1
+        h1.mtn.em-600.pos-rel
           fiat(btc="getTotal(accountIndex)")
       span(ng-show="isBitCurrency(settings.displayCurrency)")
-        h1 {{ getTotal(accountIndex) | toBitCurrency:settings.btcCurrency }}
-      p
+        h1.mtn.em-600.pos-rel {{ getTotal(accountIndex) | toBitCurrency:settings.btcCurrency }}
+      p.mvn.type-h4.em-300.align-offset.pos-rel
         fiat(btc="getTotal(accountIndex)", ng-show="isBitCurrency(settings.displayCurrency)")
         span(ng-hide="isBitCurrency(settings.displayCurrency)")
           span {{ getTotal(accountIndex) | toBitCurrency:settings.btcCurrency }}

--- a/assets/css/components/_button-groups.scss
+++ b/assets/css/components/_button-groups.scss
@@ -4,13 +4,11 @@
     margin-right: .25em;
   }
   button, a {
-    padding: .25em .8em;
-    background: #FEFEFE;
+    padding: .25em;
     border: 1px solid #e0e0e0;
     border-radius: 5px;
-    font-weight: 300;
-    font-size: 1.4em;
-    min-width: 115px;
+    font-size: 1.2em;
+    min-width: 100px;
     transition: all .2s ease-in-out;
     color: $text;
     &:hover {

--- a/assets/css/components/_filter-bar.scss
+++ b/assets/css/components/_filter-bar.scss
@@ -2,7 +2,7 @@
   position: fixed;
   width: calc(100% - 270px);
   left: 270px;
-  top: 165px;
+  top: 195px;
   height: 50px;
   background: $light-blue;
   padding: 0 30px;
@@ -71,7 +71,7 @@
 @media (max-width: 768px) {
   .filter-bar {
     width: 100%;
-    top: 130px;
+    top: 160px;
     left: 0;
     border-top: 1px solid $eee
   }

--- a/assets/css/modules/_layout.scss
+++ b/assets/css/modules/_layout.scss
@@ -27,30 +27,22 @@
   margin-left: 270px;
   border-bottom: 1px solid $border-grey;
   padding: 0 30px;
-  height: 100px;
+  height: 130px;
   top: 65px;
-  .balance {
-    cursor: pointer;
-    h1 {
-      font-size: 2.5em;
-      font-weight: 600;
-    }
-    p {
-      margin-top: 0px;
-      float: right;
-      font-size: 1.3em;
-    }
+  .heavy {
+    h1 { font-size: 2.3em; }
     img.spinner {
       height: 11px;
     }
   }
+  .align-offset { top: -6px; }
 }
 
 .main-container {
   background: white;
   position: relative;
   left: 270px;
-  top: 90px;
+  top: 120px;
   overflow-y: scroll;
   overflow-x: hidden;
   width: calc(100% - 270px);
@@ -74,7 +66,7 @@
     width: 100%;
     position: relative;
     margin-left: 0;
-    height: 80px;
+    height: 95px;
     top: 0px;
   }
   .transactions { top: 0; }
@@ -86,11 +78,14 @@
 }
 
 @media (max-width: 992px) {
-  .top-view .balance h1 { font-size: 2em; }
+  .top-view .heavy h1 { font-size: 1.75em; }
+  .top-view .heavy p { font-size: 1em; }
 }
 
 @media (max-width: 768px) {
-  .top-view .balance h1 { font-size: 1.25em; }
-  .top-view .balance p { font-size: .9em; }
+  .top-view .my-wallet { display: none; }
+  .top-view .heavy h1 { font-size: 1.25em; }
+  .top-view .heavy p { font-size: .9em; }
+  .top-view .heavy .em-600 { top: -6px; }
 }
 


### PR DESCRIPTION
We're gonna switch the design up a bit in the "top" view to include My Wallet, Be your own bank. This will ease existing users who are used to the legacy design/nav.
<img width="1552" alt="screen shot 2015-09-08 at 4 50 27 pm" src="https://cloud.githubusercontent.com/assets/824209/9748085/334776d6-5650-11e5-818f-733e2f44a39b.png">
