### PR TITLE
Add mock balance history chart

### DIFF
--- a/app/partials/home.jade
+++ b/app/partials/home.jade
@@ -20,3 +20,13 @@
               ac-config="pieChartConfig"
               ng-show="accounts().length > 1 && getTotal() > 0"
             )
+      .section
+        .charts.pos-rel
+          h5.aaa.em-400.mbl(translate="BALANCE_OVER_TIME")
+          .widget.flex-center.flex-justify.pos-rel(ng-class="{ 'empty' : !balanceHistory().length}")
+            #balance-history-chart.chart(
+              ac-chart="'line'"
+              ac-data="lineChartData"
+              ac-config="lineChartConfig"
+              ng-show="balanceHistory().length > 1"
+            )

--- a/assets/js/controllers/home_ctrl.js.coffee
+++ b/assets/js/controllers/home_ctrl.js.coffee
@@ -56,13 +56,27 @@ walletApp.controller "HomeCtrl", ($q, $scope, $window, Wallet, $modal) ->
     tooltip: $scope.convertToDisplay(account.balance)
 
   $scope.balanceHistoryDataFormat = (entry) ->
+    currency = $scope.settings.currency
+    if currency and currency.code
+      # Check that there is a valid conversion
+      conversion = $scope.conversions[currency.code]
+      if conversion and conversion.conversion > 0
+        return $q (resolve, reject) ->
+          Wallet.getFiatAtTime(entry.balance, entry.timestamp, currency.code).then(resolve, reject)
+        .then (amount) ->
+          return {
+            x: entry.date
+            y: [parseFloat(amount)]
+            tooltip: conversion.symbol + amount
+          }
+
     currency = $scope.settings.displayCurrency
     amount = Wallet.convertFromSatoshi(entry.balance, currency)
-    return {
+    return $q({
       x: entry.date
       y: [amount]
       tooltip: $scope.convertToDisplay(entry.balance)
-    }
+    })
 
   $scope.sumReduceAccounts = (prev, current) ->
     balance: prev.balance + current.balance
@@ -123,14 +137,20 @@ walletApp.controller "HomeCtrl", ($q, $scope, $window, Wallet, $modal) ->
         seenDates.push entry.date
         consolidatedHistory.push entry
 
-    consolidatedHistory.map($scope.balanceHistoryDataFormat)
+    promises = []
+
+    for entry in consolidatedHistory
+      promises.push $scope.balanceHistoryDataFormat(entry)
+
+    return $q.all(promises)
 
   # Call when chart needs to be updated
   $scope.updatePieChartData = () ->
     $scope.pieChartData.data = $scope.accountData(4)
 
   $scope.updateLineChartData = () ->
-    $scope.lineChartData.data = $scope.balanceHistoryData()
+    $scope.balanceHistoryData().then (data) ->
+      $scope.lineChartData.data = data
 
   # Watchers
   loadedTxs = $scope.$watch 'status.didLoadTransactions', (didLoad) ->

--- a/assets/js/controllers/home_ctrl.js.coffee
+++ b/assets/js/controllers/home_ctrl.js.coffee
@@ -97,7 +97,7 @@ walletApp.controller "HomeCtrl", ($q, $scope, $window, Wallet, $modal) ->
     largestAccounts.push(otherAccounts) unless otherAccounts.balance == 0
     largestAccounts.map($scope.chartDataFormat)
 
-  $scope.balanceHistoryData = () ->
+  $scope.balanceHistoryData = (forceBTC = false) ->
     history = Wallet.balanceHistory()
 
     history.sort (a, b) ->

--- a/assets/js/controllers/home_ctrl.js.coffee
+++ b/assets/js/controllers/home_ctrl.js.coffee
@@ -141,7 +141,7 @@ walletApp.controller "HomeCtrl", ($q, $scope, $window, Wallet, $modal) ->
     promises = []
 
     for entry in consolidatedHistory
-      promises.push $scope.balanceHistoryDataFormat(entry)
+      promises.push $scope.balanceHistoryDataFormat(entry, forceBTC)
 
     return $q.all(promises)
 

--- a/assets/js/controllers/home_ctrl.js.coffee
+++ b/assets/js/controllers/home_ctrl.js.coffee
@@ -22,6 +22,16 @@ walletApp.controller "HomeCtrl", ($scope, $window, Wallet, $modal) ->
     waitForHeightAndWidth: true
   }
 
+  $scope.lineChartData = { series: [''], data: [] }
+
+  $scope.lineChartConfig = {
+    colors: [ 'RGB(96, 178, 224)' ]
+    labels: false
+    waitForHeightAndWidth: true
+    isAnimate: true
+    xAxisMaxTicks: 5
+  }
+
   # accountData helper functions
   $scope.convertToDisplay = (amount) ->
     currency = $scope.settings.displayCurrency

--- a/assets/js/controllers/home_ctrl.js.coffee
+++ b/assets/js/controllers/home_ctrl.js.coffee
@@ -1,4 +1,4 @@
-walletApp.controller "HomeCtrl", ($scope, $window, Wallet, $modal) ->
+walletApp.controller "HomeCtrl", ($q, $scope, $window, Wallet, $modal) ->
   $scope.accounts = Wallet.accounts
   $scope.balanceHistory = Wallet.balanceHistory
   $scope.status = Wallet.status

--- a/assets/js/controllers/home_ctrl.js.coffee
+++ b/assets/js/controllers/home_ctrl.js.coffee
@@ -73,7 +73,7 @@ walletApp.controller "HomeCtrl", ($q, $scope, $window, Wallet, $modal) ->
 
     currency = $scope.settings.displayCurrency
     amount = Wallet.convertFromSatoshi(entry.balance, currency)
-    return $q({
+    return $q.when({
       x: entry.date
       y: [amount]
       tooltip: $scope.convertToDisplay(entry.balance)

--- a/assets/js/controllers/home_ctrl.js.coffee
+++ b/assets/js/controllers/home_ctrl.js.coffee
@@ -81,6 +81,49 @@ walletApp.controller "HomeCtrl", ($scope, $window, Wallet, $modal) ->
     largestAccounts.push(otherAccounts) unless otherAccounts.balance == 0
     largestAccounts.map($scope.chartDataFormat)
 
+  $scope.balanceHistoryData = () ->
+    history = Wallet.balanceHistory()
+
+    history.sort (a, b) ->
+      if a.timestamp > b.timestamp
+        return 1
+      else if a.timestamp < b.timestamp
+        return -1
+      else
+        return 0
+
+    # TODO: Internationalize this
+    month = [
+      "Jan"
+      "Feb"
+      "Mar"
+      "Apr"
+      "May"
+      "Jun"
+      "Jul"
+      "Aug"
+      "Sep"
+      "Oct"
+      "Nov"
+      "Dec"
+    ]
+
+    # Loop through history and only display the last balance for each day
+    seenDates = []
+    consolidatedHistory = []
+
+    for entry in history
+      date = new Date(entry.timestamp)
+      entry.date = (month[date.getMonth()] + ' ' + date.getDate())
+
+      if entry.date in seenDates
+        consolidatedHistory[consolidatedHistory.length - 1] = entry
+      else
+        seenDates.push entry.date
+        consolidatedHistory.push entry
+
+    consolidatedHistory.map($scope.balanceHistoryDataFormat)
+
   # Call when chart needs to be updated
   $scope.updatePieChartData = () ->
     $scope.pieChartData.data = $scope.accountData(4)

--- a/assets/js/controllers/home_ctrl.js.coffee
+++ b/assets/js/controllers/home_ctrl.js.coffee
@@ -54,6 +54,15 @@ walletApp.controller "HomeCtrl", ($scope, $window, Wallet, $modal) ->
     y: [account.balance]
     tooltip: $scope.convertToDisplay(account.balance)
 
+  $scope.balanceHistoryDataFormat = (entry) ->
+    currency = $scope.settings.displayCurrency
+    amount = Wallet.convertFromSatoshi(entry.balance, currency)
+    return {
+      x: entry.date
+      y: [amount]
+      tooltip: $scope.convertToDisplay(entry.balance)
+    }
+
   $scope.sumReduceAccounts = (prev, current) ->
     balance: prev.balance + current.balance
     label: 'Remaining Accounts'

--- a/assets/js/controllers/home_ctrl.js.coffee
+++ b/assets/js/controllers/home_ctrl.js.coffee
@@ -55,20 +55,21 @@ walletApp.controller "HomeCtrl", ($q, $scope, $window, Wallet, $modal) ->
     y: [account.balance]
     tooltip: $scope.convertToDisplay(account.balance)
 
-  $scope.balanceHistoryDataFormat = (entry) ->
-    currency = $scope.settings.currency
-    if currency and currency.code
-      # Check that there is a valid conversion
-      conversion = $scope.conversions[currency.code]
-      if conversion and conversion.conversion > 0
-        return $q (resolve, reject) ->
-          Wallet.getFiatAtTime(entry.balance, entry.timestamp, currency.code).then(resolve, reject)
-        .then (amount) ->
-          return {
-            x: entry.date
-            y: [parseFloat(amount)]
-            tooltip: conversion.symbol + amount
-          }
+  $scope.balanceHistoryDataFormat = (entry, forceBTC) ->
+    unless forceBTC
+      currency = $scope.settings.currency
+      if currency and currency.code
+        # Check that there is a valid conversion
+        conversion = $scope.conversions[currency.code]
+        if conversion and conversion.conversion > 0
+          return $q (resolve, reject) ->
+            Wallet.getFiatAtTime(entry.balance, entry.timestamp, currency.code).then(resolve, reject)
+          .then (amount) ->
+            return {
+              x: entry.date
+              y: [parseFloat(amount)]
+              tooltip: conversion.symbol + amount
+            }
 
     currency = $scope.settings.displayCurrency
     amount = Wallet.convertFromSatoshi(entry.balance, currency)

--- a/assets/js/controllers/home_ctrl.js.coffee
+++ b/assets/js/controllers/home_ctrl.js.coffee
@@ -3,6 +3,7 @@ walletApp.controller "HomeCtrl", ($scope, $window, Wallet, $modal) ->
   $scope.balanceHistory = Wallet.balanceHistory
   $scope.status = Wallet.status
   $scope.settings = Wallet.settings
+  $scope.conversions = Wallet.conversions
   $scope.getTotal = () -> Wallet.total('accounts')
   $scope.empty = false
   $scope.transactions = []

--- a/assets/js/controllers/home_ctrl.js.coffee
+++ b/assets/js/controllers/home_ctrl.js.coffee
@@ -29,6 +29,10 @@ walletApp.controller "HomeCtrl", ($scope, $window, Wallet, $modal) ->
     labels: false
     waitForHeightAndWidth: true
     isAnimate: true
+    legend: {
+      display: false
+      position: 'right'
+    }
     xAxisMaxTicks: 5
   }
 

--- a/assets/js/controllers/home_ctrl.js.coffee
+++ b/assets/js/controllers/home_ctrl.js.coffee
@@ -152,6 +152,9 @@ walletApp.controller "HomeCtrl", ($q, $scope, $window, Wallet, $modal) ->
   $scope.updateLineChartData = () ->
     $scope.balanceHistoryData().then (data) ->
       $scope.lineChartData = { series: [''], data: data }
+    , (error) ->
+      $scope.balanceHistoryData(true).then (data) ->
+        $scope.lineChartData = { series: [''], data: data }
 
   # Watchers
   loadedTxs = $scope.$watch 'status.didLoadTransactions', (didLoad) ->

--- a/assets/js/controllers/home_ctrl.js.coffee
+++ b/assets/js/controllers/home_ctrl.js.coffee
@@ -142,6 +142,11 @@ walletApp.controller "HomeCtrl", ($scope, $window, Wallet, $modal) ->
     $scope.updatePieChartData()
     loadedBalances()
 
+  loadedBalanceHistory = $scope.$watch 'status.didLoadBalanceHistory', (didLoad) ->
+    return unless didLoad
+    $scope.updateLineChartData()
+    loadedBalanceHistory()
+
   $scope.$watch 'settings.displayCurrency', ->
     $scope.updatePieChartData()
 

--- a/assets/js/controllers/home_ctrl.js.coffee
+++ b/assets/js/controllers/home_ctrl.js.coffee
@@ -1,5 +1,6 @@
 walletApp.controller "HomeCtrl", ($scope, $window, Wallet, $modal) ->
   $scope.accounts = Wallet.accounts
+  $scope.balanceHistory = Wallet.balanceHistory
   $scope.status = Wallet.status
   $scope.settings = Wallet.settings
   $scope.getTotal = () -> Wallet.total('accounts')

--- a/assets/js/controllers/home_ctrl.js.coffee
+++ b/assets/js/controllers/home_ctrl.js.coffee
@@ -24,7 +24,7 @@ walletApp.controller "HomeCtrl", ($q, $scope, $window, Wallet, $modal) ->
     waitForHeightAndWidth: true
   }
 
-  $scope.lineChartData = { series: [''], data: [] }
+  $scope.lineChartData = {}
 
   $scope.lineChartConfig = {
     colors: [ 'RGB(96, 178, 224)' ]
@@ -150,7 +150,7 @@ walletApp.controller "HomeCtrl", ($q, $scope, $window, Wallet, $modal) ->
 
   $scope.updateLineChartData = () ->
     $scope.balanceHistoryData().then (data) ->
-      $scope.lineChartData.data = data
+      $scope.lineChartData = { series: [''], data: data }
 
   # Watchers
   loadedTxs = $scope.$watch 'status.didLoadTransactions', (didLoad) ->

--- a/assets/js/controllers/home_ctrl.js.coffee
+++ b/assets/js/controllers/home_ctrl.js.coffee
@@ -128,6 +128,9 @@ walletApp.controller "HomeCtrl", ($scope, $window, Wallet, $modal) ->
   $scope.updatePieChartData = () ->
     $scope.pieChartData.data = $scope.accountData(4)
 
+  $scope.updateLineChartData = () ->
+    $scope.lineChartData.data = $scope.balanceHistoryData()
+
   # Watchers
   loadedTxs = $scope.$watch 'status.didLoadTransactions', (didLoad) ->
     return unless didLoad

--- a/assets/js/services/wallet.js.coffee
+++ b/assets/js/services/wallet.js.coffee
@@ -839,6 +839,9 @@ walletServices.factory "Wallet", ($log, $http, $window, $timeout, MyWallet, MyBl
       wallet.updateTransactions()
       wallet.status.didLoadBalances = true if wallet.my.wallet.isUpgradedToHD
       wallet.applyIfNeeded()
+    else if event == "did_load_balance_history"
+      wallet.status.didLoadBalanceHistory = true if wallet.my.wallet.isUpgradedToHD
+      wallet.applyIfNeeded()
     else if event == "did_update_legacy_address_balance"
       console.log "did_update_legacy_address_balance"
       wallet.applyIfNeeded()

--- a/assets/js/services/wallet.js.coffee
+++ b/assets/js/services/wallet.js.coffee
@@ -111,6 +111,7 @@ walletServices.factory "Wallet", ($log, $http, $window, $timeout, MyWallet, MyBl
         # Fetch transactions:
         if wallet.my.wallet.isUpgradedToHD
           wallet.my.getHistoryAndParseMultiAddressJSON()
+          wallet.my.getBalanceHistory()
 
         wallet.applyIfNeeded()
       )

--- a/assets/js/services/wallet.js.coffee
+++ b/assets/js/services/wallet.js.coffee
@@ -758,6 +758,12 @@ walletServices.factory "Wallet", ($log, $http, $window, $timeout, MyWallet, MyBl
     else
       return []
 
+  wallet.balanceHistory = () ->
+    if wallet.my.wallet.hdwallet?
+      return wallet.my.wallet.hdwallet.balanceHistory
+    else
+      return []
+
   # wallet.status.didLoadBalances = true if wallet.accounts? && wallet.accounts().length > 0 && wallet.accounts().some((a) -> a.active and a.balance)
 
   wallet.total = (accountIndex) ->

--- a/assets/js/services/wallet.js.coffee
+++ b/assets/js/services/wallet.js.coffee
@@ -22,7 +22,7 @@ walletServices = angular.module("walletServices", [])
 walletServices.factory "Wallet", ($log, $http, $window, $timeout, MyWallet, MyBlockchainApi, MyBlockchainSettings, MyWalletStore, MyWalletSpender, $rootScope, ngAudio, $cookieStore, $translate, $filter, $state, $q) ->
   wallet = {
     goal: {auth: false},
-    status: {isLoggedIn: false, didUpgradeToHd: null, didInitializeHD: false, didLoadSettings: false, didLoadTransactions: false, didLoadBalances: false, didConfirmRecoveryPhrase: false},
+    status: {isLoggedIn: false, didUpgradeToHd: null, didInitializeHD: false, didLoadSettings: false, didLoadTransactions: false, didLoadBalances: false, didConfirmRecoveryPhrase: false, didLoadBalanceHistory: false},
     settings: {currency: null,  displayCurrency: null, language: null, btcCurrency: null, needs2FA: null, twoFactorMethod: null, feePerKB: null, handleBitcoinLinks: false, blockTOR: null, rememberTwoFactor: null, secondPassword: null, ipWhitelist: null, apiAccess: null, restrictToWhitelist: null, loggingLevel: null},
     user: {current_ip: null, email: null, mobile: null, passwordHint: ""}
   }

--- a/locales/en-human.json
+++ b/locales/en-human.json
@@ -556,6 +556,7 @@
   "SIGNOUT": "Sign out",
   "EDIT_NOTE": "Edit",
   "DELETE_NOTE": "Delete",
-  "ALPHA_WARNING": "Please note, this is an Alpha of a new product. Please do not test this wallet with more funds than you are willing to lose."
+  "ALPHA_WARNING": "Please note, this is an Alpha of a new product. Please do not test this wallet with more funds than you are willing to lose.",
+  "BALANCE_OVER_TIME": "Balance Over Time"
 
 }

--- a/tests/services/wallet/signup_login_2ndpw_sync_upgrade.coffee
+++ b/tests/services/wallet/signup_login_2ndpw_sync_upgrade.coffee
@@ -37,6 +37,8 @@ describe "walletServices", () ->
           success()
 
         getHistoryAndParseMultiAddressJSON: () ->
+
+        getBalanceHistory: () ->
       }
 
       Wallet.settings_api.get_account_info = (success, error) ->

--- a/tests/services/wallet_service_spec.coffee
+++ b/tests/services/wallet_service_spec.coffee
@@ -33,6 +33,8 @@ describe "walletServices", () ->
 
       Wallet.my.getHistoryAndParseMultiAddressJSON = () ->
 
+      Wallet.my.getBalanceHistory = () ->
+
       Wallet.api.get_ticker = (success, fail) ->
         success({
           EUR: {"last": 250, symbol: "€"}


### PR DESCRIPTION
Depends on https://github.com/blockchain/My-Wallet-V3/pull/34

I'd note that in the future, it's probably better to return a sorted daily average (or ending) balance from the API itself, rather than requiring the frontend to sort and filter unix timestamps. `angular-charts` seems to get mad if you try giving it empty data points to actually space out dates, so it'd be nice to not have to fill in the blanks in the frontend.

Ideally, you'd want to specify `start` and `end` query params with unambiguous dateints to specify a date range, so you could show the balance over "Last 7 Days", "Last 30 Days", "August", etc.

TODO: Space dates out evenly by creating points for missing dates, internationalize month abbreviations.