### PR TITLE
feat(security-center): set default score > 0 for new wallet creation

### DIFF
--- a/assets/css/components/_progress-bars.scss
+++ b/assets/css/components/_progress-bars.scss
@@ -2,26 +2,19 @@
   background: $security-green;
   border-radius: 10px !important;
 }
-
-.level-3, .level-4, .level-5 {
-  background: $security-yellow;
+.level-3, .level-4, .level-5 { background: $security-yellow; }
+.level-0, .level-1, .level-2 { background: $security-red; }
+.level-0 { width: 5%; }
+[class^='level-'], [class*=' level-']{
+  height: 100%;
+  transition: width .3s ease-in-out;
 }
-
-.level-1, .level-2 {
-  background: $security-red;
-}
-
-@for $i from 0 through 6 {
+@for $i from 1 through 6 {
   .level-#{$i} {
     width: calc(#{$i}/6 * 100%);
-    height: 100%;
-    transition: width .3s ease-in-out;
   }
 }
-
-.bar {
-  border-radius: 10px 0 0 10px;
-}
+.bar { border-radius: 10px 0 0 10px; }
 
 .progress-bar-wrapper {
   border-radius: 10px;


### PR DESCRIPTION
Set the progress bar score to a default first time 5% score via the UI
![screen shot 2015-09-11 at 10 47 17 am](https://cloud.githubusercontent.com/assets/824209/9817720/a8b3a61e-5872-11e5-90da-9ded69b1ef1b.png)
