### PR TITLE
Modals can have their own alert context

### DIFF
--- a/assets/js/controllers/second_password_ctrl.js.coffee
+++ b/assets/js/controllers/second_password_ctrl.js.coffee
@@ -1,6 +1,6 @@
 walletApp.controller "SecondPasswordCtrl", ($scope, $log, Wallet, $modalInstance, $translate, insist, defer) ->
   $scope.insist = if insist then true else false
-  $scope.alerts = Wallet.alerts
+  $scope.alerts = []
 
   $scope.busy = false
 
@@ -24,4 +24,4 @@ walletApp.controller "SecondPasswordCtrl", ($scope, $log, Wallet, $modalInstance
     else
       $scope.busy = false
       $translate("SECOND_PASSWORD_INCORRECT").then (translation) ->
-        Wallet.displayError(translation)
+        Wallet.displayError(translation, false, $scope.alerts)

--- a/assets/js/controllers/send_ctrl.js.coffee
+++ b/assets/js/controllers/send_ctrl.js.coffee
@@ -15,7 +15,7 @@ walletApp.controller "SendCtrl", ($scope, $log, Wallet, $modalInstance, $timeout
   $scope.sending = false # Sending in progress
   $scope.amountIsValid = true
 
-  $scope.alerts = Wallet.alerts
+  $scope.alerts = []
 
   $scope.fiatCurrency = Wallet.settings.currency
   $scope.btcCurrency = Wallet.settings.btcCurrency
@@ -57,7 +57,7 @@ walletApp.controller "SendCtrl", ($scope, $log, Wallet, $modalInstance, $timeout
   $scope.onError = (error) ->
     # This never gets called...
     $translate("CAMERA_PERMISSION_DENIED").then (translation) ->
-      Wallet.displayWarning(translation)
+      Wallet.displayWarning(translation, false, $scope.alerts)
 
   $scope.applyPaymentRequest = (paymentRequest, i) ->
     $scope.processingPaymentRequest = true
@@ -91,7 +91,7 @@ walletApp.controller "SendCtrl", ($scope, $log, Wallet, $modalInstance, $timeout
       $scope.cameraOff()
     else
       $translate("QR_CODE_NOT_BITCOIN").then (translation) ->
-        Wallet.displayWarning(translation)
+        Wallet.displayWarning(translation, false, $scope.alerts)
 
       $log.error "Not a bitcoin QR code:" + url
 
@@ -146,7 +146,7 @@ walletApp.controller "SendCtrl", ($scope, $log, Wallet, $modalInstance, $timeout
 
     transactionFailed = (message) ->
       $scope.sending = false
-      $translate(message).then((t) -> Wallet.displayError(t)) if message
+      $translate(message).then((t) -> Wallet.displayError(t, false, $scope.alerts)) if message
 
     transactionSucceeded = (tx_hash) ->
       $scope.sending = false

--- a/assets/js/services/wallet.js.coffee
+++ b/assets/js/services/wallet.js.coffee
@@ -694,30 +694,36 @@ walletServices.factory "Wallet", ($log, $http, $window, $timeout, MyWallet, MyBl
       if alert?
         $timeout.cancel(alert.timer)
 
-  wallet.displayInfo = (message, keep=false) ->
-    wallet.displayAlert {type: "info", msg: message}, keep
+  wallet.displayInfo = (message, keep, context) ->
+    wallet.displayAlert {type: "info", msg: message}, keep, context
 
-  wallet.displaySuccess = (message, keep=false) ->
-    wallet.displayAlert {type: "success", msg: message}, keep
+  wallet.displaySuccess = (message, keep, context) ->
+    wallet.displayAlert {type: "success", msg: message}, keep, context
 
-  wallet.displayWarning = (message, keep=false) ->
-    wallet.displayAlert  {msg: message}, keep
+  wallet.displayWarning = (message, keep, context) ->
+    wallet.displayAlert  {msg: message}, keep, context
 
-  wallet.displayError = (message, keep=false) ->
-    wallet.displayAlert {type: "danger", msg: message}, keep
+  wallet.displayError = (message, keep, context) ->
+    wallet.displayAlert {type: "danger", msg: message}, keep, context
 
   wallet.displayReceivedBitcoin = () ->
     $translate("JUST_RECEIVED_BITCOIN").then (translation) ->
       wallet.displayAlert {type: "received-bitcoin", msg: translation}
 
-  wallet.displayAlert = (alert, keep=false) ->
+  wallet.displayAlert = (alert, keep=false, context) ->
+    if context == undefined
+      context = wallet.alerts
+
+    if keep == undefined
+      keep = false
+
     if !keep
       wallet.lastAlertId++
       alert.timer = $timeout((->
-        wallet.alerts.splice(wallet.alerts.indexOf(alert))
+        context.splice(context.indexOf(alert))
       ), 7000)
 
-    wallet.alerts.push(alert)
+    context.push(alert)
 
   wallet.isSynchronizedWithServer = () ->
     return wallet.store.isSynchronizedWithServer()

--- a/tests/controllers/send_ctrl_spec.coffee
+++ b/tests/controllers/send_ctrl_spec.coffee
@@ -379,7 +379,8 @@ describe "SendCtrl", ->
           scope.send()
           scope.$digest()
           expect(scope.alerts.length).toEqual(1)
-          expect(Wallet.displayError).toHaveBeenCalledWith('err_message')
+          expect(Wallet.displayError).toHaveBeenCalled()
+          expect(Wallet.displayError.calls.argsFor(0)[0]).toEqual('err_message')
         )
 
       describe "success", ->


### PR DESCRIPTION
This prevents error messages from being displayed in two or three
places at the same time.
![schermafbeelding 2015-09-11 om 13 56 34](https://cloud.githubusercontent.com/assets/10217/9822173/f26879aa-588c-11e5-9f32-6a68ac2127da.png)