### PR TITLE
Don't show historical value for the first hour

### DIFF
--- a/app/partials/transaction.jade
+++ b/app/partials/transaction.jade
@@ -29,7 +29,7 @@
             amount(transaction="transaction" btc)
           .tx-status
             transaction-status(transaction="transaction")
-          .center-align.mbm(ng-show="settings.currency.code == 'USD'")
+          .center-align.mbm(ng-show="settings.currency.code == 'USD' && transaction.confirmations > 5")
             p.mbn(translate="VALUE_AT_SEND")
             fiat.em-600(btc="transaction.result" abs date="transaction.txTime")
           .center-align.mbm


### PR DESCRIPTION
This prevents confusion, since the historical conversion rates are calculated slightly differently than then present one.