### PR TITLE
fix(Send): press enter does the right thing

### DIFF
--- a/app/partials/send.jade
+++ b/app/partials/send.jade
@@ -58,7 +58,7 @@
               )
                 ui-select-match(placeholder="Paste, scan or select address") {{ $select.selected.label }}
                 ui-select-choices(
-                  repeat="destination in filterDestinations($index, !advanced)"
+                  repeat="destination in filterDestinations($index, !advanced, $select.search)"
                   group-by="'type'" 
                   refresh="refreshDestinations($select.search, $index)" 
                   refresh-delay="0"

--- a/assets/js/controllers/send.controller.js
+++ b/assets/js/controllers/send.controller.js
@@ -47,9 +47,19 @@ function SendCtrl($scope, $log, Wallet, $modalInstance, $timeout, $state, $filte
     type: accounts ? '!External' : 'Imported'
   });
 
-  $scope.filterDestinations = (destinationsIdx, showAccounts=true) => {
+  $scope.filterDestinations = (destinationsIdx, showAccounts, query) => {
     return $scope.destinations[destinationsIdx].filter(dest => {
       if (dest.type == "External" && dest.address == "") {
+        return false;
+      }
+      if (!!dest.address && dest.address != "") {
+        // If it's an address, match either address or label
+        if(!dest.address.toLowerCase().includes(query.toLowerCase()) & !dest.label.toLowerCase().includes(query.toLowerCase())) {
+          return false;
+        }
+      }
+      // If it's an account, only match the label
+      if (!!dest.label && dest.label != "" && !dest.label.toLowerCase().includes(query.toLowerCase())) {
         return false;
       }
       return showAccounts || dest.type !== 'Accounts';


### PR DESCRIPTION
The destinations list is filtered as the user types. If the user copy-pastes an address that will be the only option left. That way if they hit enter, the correct address is selected (rather than falling back to the first account).