### PR TITLE
Only ask 2nd password once when importing BIP38

### DIFF
--- a/assets/js/controllers/settings/addressImport.controller.js
+++ b/assets/js/controllers/settings/addressImport.controller.js
@@ -50,10 +50,12 @@ function AddressImportCtrl($scope, $log, Wallet, $modalInstance, $translate, $st
         case 'wrongBipPass':
           $scope.importForm.bipPassphrase.$setValidity('wrong', false);
           break;
-        case 'needsBip38':
-          $scope.BIP38 = true;
-          break;
       }
+    };
+
+    const needsBipPassphrase = (proceed) => {
+      $scope.BIP38 = true;
+      $scope.proceedWithBip38 = proceed;
     };
 
     const cancel = () => {
@@ -61,9 +63,13 @@ function AddressImportCtrl($scope, $log, Wallet, $modalInstance, $translate, $st
     };
 
     $timeout(() => {
-      Wallet.addAddressOrPrivateKey(
-        addressOrPrivateKey, bip38passphrase, success, error, cancel
-      );
+      if(!$scope.BIP38) {
+        Wallet.addAddressOrPrivateKey(
+          addressOrPrivateKey, needsBipPassphrase, success, error, cancel
+        );
+      } else {
+        $scope.proceedWithBip38(bip38passphrase);
+      }
     }, 250);
   };
 

--- a/assets/js/controllers/settings/addressImport.controller.js
+++ b/assets/js/controllers/settings/addressImport.controller.js
@@ -39,10 +39,8 @@ function AddressImportCtrl($scope, $log, Wallet, $modalInstance, $translate, $st
       $scope.step = 2;
     };
 
-    const error = (err, address) => {
+    const error = (err) => {
       $scope.status.busy = false;
-      if (address == null) address = null;
-      if (err == null) return;
       switch (err) {
         case 'presentInWallet':
           $scope.importForm.privateKey.$setValidity('present', false);
@@ -54,6 +52,7 @@ function AddressImportCtrl($scope, $log, Wallet, $modalInstance, $translate, $st
     };
 
     const needsBipPassphrase = (proceed) => {
+      $scope.status.busy = false;
       $scope.BIP38 = true;
       $scope.proceedWithBip38 = proceed;
     };

--- a/tests/services/wallet_service_spec.coffee
+++ b/tests/services/wallet_service_spec.coffee
@@ -421,15 +421,17 @@ describe "walletServices", () ->
       callbacks = {
         success: () ->
         error: () ->
+        needsBip38: () ->
       }
 
       spyOn(callbacks, "error")
+      spyOn(callbacks, "needsBip38")
 
-      Wallet.addAddressOrPrivateKey("BIP38 key", "", callbacks.success, callbacks.error)
+      Wallet.addAddressOrPrivateKey("BIP38 key", callbacks.needsBip38, callbacks.success, callbacks.error)
 
       $rootScope.$digest()
 
-      expect(callbacks.error).toHaveBeenCalledWith("needsBip38")
+      expect(callbacks.needsBip38).toHaveBeenCalled()
     )
 
   describe "displayReceivedBitcoin()", ->


### PR DESCRIPTION
Wallet.addAddressOrPrivateKey() was called twice if a BIP38 encoded key was imported. As in the past I'm using a callback to prevent that. There might be a way to replace this callback hell with promises.