### PR TITLE
Prevent overflow of 'Verify on bc.i' in Chrome

### DIFF
--- a/assets/css/modules/_transaction-list.scss
+++ b/assets/css/modules/_transaction-list.scss
@@ -127,6 +127,10 @@ a.date,p.date { color: $black; }
   }
 }
 
+.tx-bci-link {
+  min-width: -webkit-min-content;
+}
+
 @media (min-width: 992px){
   .amountTotal{float: right;}
 }


### PR DESCRIPTION
It seems to be related to this: http://stackoverflow.com/a/28034526

This PR fixes it for Chrome, but not for IE.

cc @abhisharma2 