### PR TITLE
Show default account again

### DIFF
--- a/assets/js/controllers/settings/accounts.controller.js
+++ b/assets/js/controllers/settings/accounts.controller.js
@@ -104,6 +104,6 @@ function SettingsAccountsController($scope, Wallet, $modal, filterFilter) {
 
   $scope.archive = (account) => { Wallet.archive(account) };
   $scope.unarchive = (account) => { Wallet.unarchive(account) };
-  $scope.isDefault = (account) => { Wallet.isDefaultAccount(account) };
+  $scope.isDefault = (account) => Wallet.isDefaultAccount(account);
 
 }


### PR DESCRIPTION
Brackets were accidentally added (or return statement missing) in the conversion from coffeescript to ES6.