### PR TITLE
Support displaying transactions with multiple to accounts

### DIFF
--- a/assets/js/controllers/transaction.controller.js
+++ b/assets/js/controllers/transaction.controller.js
@@ -41,47 +41,45 @@ function TransactionCtrl($scope, Wallet, $log, $stateParams, $filter, $cookieSto
         }
 
         $scope.destinations = [];
-        if (tx.to.account != null) {
-          let accountLabel = $scope.accounts()[tx.to.account.index].label;
-          return $scope.destinations.push({
-            'address': accountLabel,
-            'amount': ''
-          });
-        } else {
 
-          const convert = (y) => (' [' + $filter('btc')(y) + ']');
-          const label = (a) => {
-            let address = $filter('getByProperty')('address', a, Wallet.legacyAddresses());
-            if ((address.label != null) && address.label !== address.address) {
-              return address.label;
-            } else {
-              return address.address;
-            }
-          };
-          const adBook = (a) => {
-            let name = Wallet.getAddressBookLabel(a);
-            return name ? name : a;
-          };
-          const makeLegacyRow = (a) => ({
-            'address': label(a.address),
-            'amount': convert(a.amount),
-            'you': '(you) '
-          });
-          const makeExternalRow = (a) => ({
-            'address': adBook(a.address),
-            'amount': convert(a.amount),
-            'you': ''
-          });
+        const convert = (y) => (' [' + $filter('btc')(y) + ']');
 
-          let l = tx.to.legacyAddresses || [];
-          let e = tx.to.externalAddresses || [];
-
-          $scope.destinations = l.map(makeLegacyRow).concat(e.map(makeExternalRow));
-
-          if ($scope.destinations.length === 1) {
-            $scope.destinations[0].amount = '';
+        const label = (a) => {
+          let address = $filter('getByProperty')('address', a, Wallet.legacyAddresses());
+          if ((address.label != null) && address.label !== address.address) {
+            return address.label;
+          } else {
+            return address.address;
           }
+        };
+        const adBook = (a) => {
+          let name = Wallet.getAddressBookLabel(a);
+          return name ? name : a;
+        };
+        const makeAccountRow = (a) => ({
+          'address': $scope.accounts()[a.index].label,
+          'amount': convert(a.amount),
+          'you': '(you) '
+        });
+        const makeLegacyRow = (a) => ({
+          'address': label(a.address),
+          'amount': convert(a.amount),
+          'you': '(you) '
+        });
+        const makeExternalRow = (a) => ({
+          'address': adBook(a.address),
+          'amount': convert(a.amount),
+          'you': ''
+        });
 
+        let a = tx.to.accounts;
+        let l = tx.to.legacyAddresses || [];
+        let e = tx.to.externalAddresses || [];
+
+        $scope.destinations = a.map(makeAccountRow).concat(l.map(makeLegacyRow)).concat(e.map(makeExternalRow));
+
+        if ($scope.destinations.length === 1) {
+          $scope.destinations[0].amount = '';
         }
       }
     });

--- a/assets/js/controllers/transactions.controller.js
+++ b/assets/js/controllers/transactions.controller.js
@@ -107,12 +107,15 @@ function TransactionsCtrl($scope, Wallet, MyWallet, $log, $stateParams, $timeout
 
   $scope.filterByLocation = item => {
     if ($stateParams.accountIndex === "accounts") {
-      return (item.to.account != null) || (item.from.account != null);
+      return (item.to.accounts.length > 0) || (item.from.account != null);
     }
     if ($stateParams.accountIndex === "imported") {
       return (item.to.legacyAddresses && item.to.legacyAddresses.length) || (item.from.legacyAddresses && item.from.legacyAddresses.length);
     }
-    return ((item.to.account != null) && item.to.account.index === parseInt($stateParams.accountIndex)) || ((item.from.account != null) && item.from.account.index === parseInt($stateParams.accountIndex));
+    return (
+      (item.to.accounts.length > 0 && item.to.accounts.some((account) => account.index === parseInt($stateParams.accountIndex))) 
+      || ((item.from.account != null) && item.from.account.index === parseInt($stateParams.accountIndex))
+    );
   };
 
   $scope.$watch("status.didLoadTransactions", newValue => {

--- a/assets/js/directives/transaction-description.js.coffee
+++ b/assets/js/directives/transaction-description.js.coffee
@@ -33,8 +33,8 @@ angular.module('walletApp').directive('transactionDescription', ($translate, $ro
 
       if scope.transaction.intraWallet
         scope.action = "MOVED_BITCOIN_TO"
-        if scope.transaction.to.account?
-          scope.address = Wallet.accounts()[parseInt(scope.transaction.to.account.index)].label
+        if scope.transaction.to.accounts.length > 0
+          scope.address = scope.transaction.to.accounts.map((account) => Wallet.accounts()[account.index].label).join(", ")
         else
           if to_name = Wallet.getAddressBookLabel(to_address)
             scope.address = to_name
@@ -66,8 +66,8 @@ angular.module('walletApp').directive('transactionDescription', ($translate, $ro
         else
           scope.other_address = from_address
       else
-        if scope.transaction.to.account?
-          scope.other_address = Wallet.accounts()[parseInt(scope.transaction.to.account.index)].label
+        if scope.transaction.to.accounts.length > 0
+          scope.other_address = Wallet.accounts()[parseInt(scope.transaction.to.accounts[0].index)].label
         else
           scope.other_address = to_address
 

--- a/tests/controllers/transaction_ctrl_spec.coffee
+++ b/tests/controllers/transaction_ctrl_spec.coffee
@@ -8,19 +8,19 @@ describe "TransactionCtrl", ->
       Wallet = $injector.get("Wallet")
 
       Wallet.accounts = () -> [{balance: 0, label: "Savings", index: 0}]
-      
+
       Wallet.legacyAddresses = () ->
         [
-          {address: "some_legacy_address", label: "Old"}, 
+          {address: "some_legacy_address", label: "Old"},
           {address: "some_legacy_address_without_label", label: null}
         ]
-      
+
       Wallet.transactions = [{
-        hash: "aaaa", 
+        hash: "aaaa",
         from: {account: null, externalAddresses: {addressWithLargestOutput: "1D2YzLr5qvrwMSm8onYbns5BLJ9jwzPHcQ"}}
-        to: {account: null}
+        to: {accounts: []}
       }]
-      
+
       spyOn(Wallet, "getAddressBookLabel").and.returnValue(null)
 
       scope = $rootScope.$new()
@@ -63,7 +63,7 @@ describe "TransactionCtrl", ->
           legacyAddresses: [{address: "some_legacy_address"}]
 
         to:
-          account: null
+          accounts: []
           legacyAddresses: []
           external:
             addressWithLargestOutput: "abc"
@@ -81,7 +81,7 @@ describe "TransactionCtrl", ->
           legacyAddresses: [{address: "some_legacy_address_without_label"}]
 
         to:
-          account: null
+          accounts: []
           legacyAddresses: []
           external:
             addressWithLargestOutput: "abc"
@@ -98,7 +98,7 @@ describe "TransactionCtrl", ->
             index: 0
           legacyAddresses: []
         to:
-          account: null
+          accounts: []
           legacyAddresses: []
           external:
             addressWithLargestOutput: "abc"
@@ -118,7 +118,7 @@ describe "TransactionCtrl", ->
           external:
             addressWithLargestOutput: "abc"
         to:
-          account: null
+          accounts: []
           legacyAddresses: [{address: "some_legacy_address"}]
 
       scope.$digest()
@@ -134,7 +134,7 @@ describe "TransactionCtrl", ->
           external:
             addressWithLargestOutput: "abc"
         to:
-          account: null
+          accounts: []
           legacyAddresses: [{address: "some_legacy_address_without_label"}]
 
 
@@ -151,7 +151,7 @@ describe "TransactionCtrl", ->
           external:
             addressWithLargestOutput: "abc"
         to:
-          account: null
+          accounts: []
           externalAddresses: [
             {address: "external address 1", amount: 50000},
             {address: "external address 2", amount: 70000}
@@ -171,8 +171,12 @@ describe "TransactionCtrl", ->
           external:
             addressWithLargestOutput: "abc"
         to:
-          account:
-            index: 0
+          accounts:[
+            {
+              index: 0
+              label: "Primary"
+            }
+          ]
           legacyAddresses: []
 
       scope.$digest()

--- a/tests/directives/transaction_description_spec.coffee
+++ b/tests/directives/transaction_description_spec.coffee
@@ -30,7 +30,7 @@ describe "Transaction Description Directive", ->
             intraWallet: null,
             txTime: 1441400781,
             from: {account: {index: 0, amount: 300000000}, legacyAddresses: null, externalAddresses: null},
-            to: {account: {index: 1, amount: 300000000}, legacyAddresses: null, externalAddresses: null}
+            to: {accounts: [{index: 1, amount: 300000000}], legacyAddresses: null, externalAddresses: null}
           }
 
     return
@@ -69,7 +69,7 @@ describe "Transaction Description Directive", ->
     expect(isoScope.other_address).toBe("Spending")
 
   it "should recognize sending from imported address", ->
-    isoScope.transaction.to.account = null
+    isoScope.transaction.to.accounts = []
     isoScope.transaction.from.account = null
     isoScope.transaction.from.legacyAddresses = {addressWithLargestOutput: "some_legacy_address", amount: 100000000}
     isoScope.transaction.to.externalAddresses = [{address: "1abcd", amount: 100000000}]
@@ -82,7 +82,7 @@ describe "Transaction Description Directive", ->
     expect(element.html()).toContain 'translate="SENT"'
 
   it "should recognize receiving to imported address", ->
-   isoScope.transaction.to.account = null
+   isoScope.transaction.to.accounts = []
    isoScope.transaction.from.account = null
    isoScope.transaction.to.legacyAddresses = {addressWithLargestOutput: "some_legacy_address", amount: 100000000}
    isoScope.transaction.from.externalAddresses = {addressWithLargestOutput: "1abcd", amount: 100000000}
@@ -97,7 +97,7 @@ describe "Transaction Description Directive", ->
 
   describe "send to email", ->
     beforeEach ->
-      isoScope.transaction.to.account = null
+      isoScope.transaction.to.accounts = []
       isoScope.transaction.to.email = {"email":"somebody@blockchain.com"}
       isoScope.result = -100000000
 


### PR DESCRIPTION
This solves the problem where when the user sends Bitcoin to multiple accounts, it only displays one account and the transaction total only represents one account.

* all to accounts are shown in the transaction details page
* all to accounts are shown in the transaction list page
* the transaction shows up in the from account tx list, as well as all to account tx list pages

This change depends on blockchain/My-Wallet-V3#43
