### PR TITLE
QR scan didn't work when importing address

### DIFF
--- a/assets/js/controllers/settings/addressImport.controller.js
+++ b/assets/js/controllers/settings/addressImport.controller.js
@@ -141,7 +141,7 @@ function AddressImportCtrl($scope, $log, Wallet, $modalInstance, $translate, $st
 
   $scope.parseBitcoinUrl = (url) => {
     url = url.split('bitcoin:');
-    url[url.length - 1];
+    return url[url.length - 1];
   };
 
   $scope.close = () => {


### PR DESCRIPTION
Return statement went missing during Coffee to ES6 conversion.