### PR TITLE
refactor(send): clean destination-input link code

### DIFF
--- a/app/templates/destination-input.jade
+++ b/app/templates/destination-input.jade
@@ -3,7 +3,7 @@
     button.form-control(
       type="button"
       ng-show="model.type === 'Accounts'"
-      ng-click="clearModel()")
+      ng-click="clearModel(); focusInput();")
       span.pull-left
         | {{ model.label }}
     input.form-control(

--- a/assets/js/directives/destinationInput.directive.js
+++ b/assets/js/directives/destinationInput.directive.js
@@ -39,7 +39,6 @@ function destinationInput($rootScope, $timeout, Wallet) {
     scope.clearModel = () => {
       scope.model = format({}, 'External');
       scope.model.address = '';
-      scope.focusInput();
       $timeout(scope.change);
     };
 
@@ -47,24 +46,15 @@ function destinationInput($rootScope, $timeout, Wallet) {
       $timeout(() => elem.find('input')[0].focus(), 50);
     };
 
-    if (!scope.model) {
-      scope.clearModel();
-    }
-
-    scope.$watch('model', scope.change);
-
-    // onBlur is triggered when the modal appears for some reason:
-    let firstBlur = true;
     scope.onBlur = () => {
-      if(firstBlur) {
-        firstBlur = false;
-        return;
-      }
       ctrl.$setTouched();
-    }
+    };
 
     scope.onFocus = () => {
       ctrl.$setUntouched();
-    }
+    };
+
+    if (!scope.model) scope.clearModel();
+    scope.$watch('model', scope.change);
   }
 }


### PR DESCRIPTION
The reason for the first blur was because clearModel gets called on load, this calls focusInput, but then the input loses focus for whatever reason, causing the blur. To fix I just decoupled focusInput from clearModel, and refer to them separately in the html