### PR TITLE
refactor(alerts): move alerts to dedicated service

### DIFF
--- a/app/index.jade
+++ b/app/index.jade
@@ -156,6 +156,7 @@ head
   script(src='build/js/services/bcTranslationLoader.service.js')
   script(src='build/js/services/didYouKnow.service.js')
   script(src='build/js/services/activity.service.js')
+  script(src='build/js/services/alerts.service.js')
   
   script(src='build/js/templates.js')
       

--- a/assets/js/controllers/alerts.controller.js
+++ b/assets/js/controllers/alerts.controller.js
@@ -2,10 +2,7 @@ angular
   .module('walletApp')
   .controller("AlertsCtrl", AlertsCtrl);
 
-function AlertsCtrl($scope, Wallet) {
-  $scope.alerts = Wallet.alerts;
-
-  $scope.closeAlert = alert => {
-    Wallet.closeAlert(alert);
-  };
+function AlertsCtrl($scope, Alerts) {
+  $scope.alerts = Alerts.alerts;
+  $scope.closeAlert = Alerts.close;
 }

--- a/assets/js/controllers/app.controller.js
+++ b/assets/js/controllers/app.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller("AppCtrl", AppCtrl);
 
-function AppCtrl($scope, Wallet, $state, $rootScope, $location, $cookieStore, $timeout, $uibModal, $window, $translate) {
+function AppCtrl($scope, Wallet, Alerts, $state, $rootScope, $location, $cookieStore, $timeout, $uibModal, $window, $translate) {
   $scope.status = Wallet.status;
   $scope.settings = Wallet.settings;
   $rootScope.isMock = Wallet.isMock;
@@ -22,7 +22,7 @@ function AppCtrl($scope, Wallet, $state, $rootScope, $location, $cookieStore, $t
   $rootScope.browserWithCamera = (navigator.getUserMedia || navigator.mozGetUserMedia || navigator.webkitGetUserMedia || navigator.msGetUserMedia) !== void 0;
 
   $scope.request = () => {
-    Wallet.clearAlerts();
+    Alerts.clear();
     let modalInstance = $uibModal.open({
       templateUrl: "partials/request.jade",
       controller: "RequestCtrl",
@@ -51,7 +51,7 @@ function AppCtrl($scope, Wallet, $state, $rootScope, $location, $cookieStore, $t
   };
 
   $scope.send = () => {
-    Wallet.clearAlerts();
+    Alerts.clear();
     let modalInstance = $uibModal.open({
       templateUrl: "partials/send.jade",
       controller: "SendCtrl",
@@ -126,7 +126,7 @@ function AppCtrl($scope, Wallet, $state, $rootScope, $location, $cookieStore, $t
           });
         }
         if (Wallet.goal.auth) {
-          Wallet.clearAlerts();
+          Alerts.clear();
           $translate(['AUTHORIZED', 'AUTHORIZED_MESSAGE']).then( translations => {
             $scope.$emit('showNotification', {
               type: 'authorization-verified',
@@ -141,7 +141,7 @@ function AppCtrl($scope, Wallet, $state, $rootScope, $location, $cookieStore, $t
     if (Wallet.goal.verifyEmail != null) {
       if (!Wallet.status.isLoggedIn) {
         $translate("PLEASE_LOGIN_FIRST").then( translation => {
-          Wallet.displayInfo(translation, true);
+          Alerts.displayInfo(translation, true);
         });
         $state.go("public.login");
         return;
@@ -152,14 +152,14 @@ function AppCtrl($scope, Wallet, $state, $rootScope, $location, $cookieStore, $t
           accountIndex: ""
         });
         $translate("EMAIL_VERIFIED").then( translation => {
-          Wallet.displaySuccess(translation);
+          Alerts.displaySuccess(translation);
         });
       };
       const error = error => {
         $state.go("/");
         console.log(error);
         $translate("EMAIL_VERIFICATION_FAILED").then( translation => {
-          Wallet.displayError(translation);
+          Alerts.displayError(translation);
         });
       };
       Wallet.verifyEmail(Wallet.goal.verifyEmail, success, error);

--- a/assets/js/controllers/claim.controller.js
+++ b/assets/js/controllers/claim.controller.js
@@ -2,11 +2,11 @@ angular
   .module('walletApp')
   .controller("ClaimCtrl", ClaimCtrl);
 
-function ClaimCtrl($scope, Wallet, $translate, $stateParams, $state) {
+function ClaimCtrl($scope, Wallet, $translate, $stateParams, $state, Alerts) {
   const balance = Wallet.fetchBalanceForRedeemCode($stateParams.code);
   Wallet.goal.claim = {code: $stateParams.code, balance: balance};
   if (!Wallet.status.isLoggedIn) {
-    Wallet.displayInfo("Please login to your wallet or create a new one to proceed.", true);
+    Alerts.displayInfo("Please login to your wallet or create a new one to proceed.", true);
     $state.go("public.login");
   }
 }

--- a/assets/js/controllers/confirmRecoveryPhrase.controller.js
+++ b/assets/js/controllers/confirmRecoveryPhrase.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller("ConfirmRecoveryPhraseCtrl", ConfirmRecoveryPhraseCtrl);
 
-function ConfirmRecoveryPhraseCtrl($scope, $log, Wallet, $modalInstance, $translate) {
+function ConfirmRecoveryPhraseCtrl($scope, $log, Wallet, Alerts, $modalInstance, $translate) {
   $scope.step = 0;
   $scope.offset = 0;
   $scope.recoveryPhrase = null;
@@ -66,7 +66,7 @@ function ConfirmRecoveryPhraseCtrl($scope, $log, Wallet, $modalInstance, $transl
 
   $scope.goToShow= () => {
     $scope.step = 1;
-    
+
     if($scope.mnemonic == null) {
       const success = mnemonic => {
         $scope.recoveryPhrase = mnemonic.split(" ");
@@ -75,7 +75,7 @@ function ConfirmRecoveryPhraseCtrl($scope, $log, Wallet, $modalInstance, $transl
 
       const error = error => {
         $translate(error).then( translation => {
-          Wallet.displayError(translation);
+          Alerts.displayError(translation);
         });
         $modalInstance.dismiss("");
       };

--- a/assets/js/controllers/login.controller.js
+++ b/assets/js/controllers/login.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller("LoginCtrl", LoginCtrl);
 
-function LoginCtrl($scope, $rootScope, $log, $http, Wallet, $cookieStore, $uibModal, $state, $timeout, $translate, filterFilter) {
+function LoginCtrl($scope, $rootScope, $log, $http, Wallet, Alerts, $cookieStore, $uibModal, $state, $timeout, $translate, filterFilter) {
   $scope.status = Wallet.status;
   $scope.settings = Wallet.settings;
   $scope.disableLogin = null;
@@ -27,12 +27,12 @@ function LoginCtrl($scope, $rootScope, $log, $http, Wallet, $cookieStore, $uibMo
         requiredVersion: 11,
         userVersion: browserDetection().version
       }).then(translation => {
-        Wallet.displayError(translation, true);
+        Alerts.displayError(translation, true);
       });
       $scope.disableLogin = true;
     } else {
       $translate("WARN_AGAINST_IE").then(translation => {
-        Wallet.displayWarning(translation, true);
+        Alerts.displayWarning(translation, true);
       });
     }
   } else if (browserDetection().browser === "chrome") {
@@ -42,7 +42,7 @@ function LoginCtrl($scope, $rootScope, $log, $http, Wallet, $cookieStore, $uibMo
         requiredVersion: 11,
         userVersion: browserDetection().version
       }).then(translation => {
-        Wallet.displayError(translation, true);
+        Alerts.displayError(translation, true);
       });
       $scope.disableLogin = true;
     }
@@ -53,7 +53,7 @@ function LoginCtrl($scope, $rootScope, $log, $http, Wallet, $cookieStore, $uibMo
         requiredVersion: 21,
         userVersion: browserDetection().version
       }).then(translation => {
-        Wallet.displayError(translation, true);
+        Alerts.displayError(translation, true);
       });
       $scope.disableLogin = true;
     }
@@ -64,7 +64,7 @@ function LoginCtrl($scope, $rootScope, $log, $http, Wallet, $cookieStore, $uibMo
         requiredVersion: 6,
         userVersion: browserDetection().version
       }).then(translation => {
-        Wallet.displayError(translation, true);
+        Alerts.displayError(translation, true);
       });
       $scope.disableLogin = true;
     }
@@ -75,14 +75,14 @@ function LoginCtrl($scope, $rootScope, $log, $http, Wallet, $cookieStore, $uibMo
         requiredVersion: 15,
         userVersion: browserDetection().version
       }).then(translation => {
-        Wallet.displayError(translation, true);
+        Alerts.displayError(translation, true);
       });
       $scope.disableLogin = true;
     }
   } else {
   // Warn against unknown browser. Tell user to pay attention to random number generator and CORS protection.
     $translate("UNKNOWN_BROWSER").then(translation => {
-      Wallet.displayWarning(translation, true);
+      Alerts.displayWarning(translation, true);
     });
   }
   if (Wallet.guid != null) {
@@ -113,7 +113,7 @@ function LoginCtrl($scope, $rootScope, $log, $http, Wallet, $cookieStore, $uibMo
   $scope.login = () => {
     if ($scope.busy) return;
     $scope.busy = true;
-    Wallet.clearAlerts();
+    Alerts.clear();
     const error = (field, message) => {
       $scope.busy = false;
       if (field === "uid") {
@@ -185,11 +185,11 @@ function LoginCtrl($scope, $rootScope, $log, $http, Wallet, $cookieStore, $uibMo
           betaCheckFinished(data.key, data.email);
         } else {
           if (data.error && data.error.message) {
-            Wallet.displayError(data.error.message);
+            Alerts.displayError(data.error.message);
           }
         }
       }).error(() => {
-        Wallet.displayError("Unable to verify your invite code.");
+        Alerts.displayError("Unable to verify your invite code.");
       });
     } else {
       $state.go("public.signup");

--- a/assets/js/controllers/lostGuid.controller.js
+++ b/assets/js/controllers/lostGuid.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('LostGuidCtrl', LostGuidCtrl);
 
-function LostGuidCtrl($scope, $http, $translate, Wallet) {
+function LostGuidCtrl($scope, $http, $translate, Wallet, Alerts) {
   $scope.currentStep = 1;
   $scope.fields = {
     email: '',
@@ -26,13 +26,13 @@ function LostGuidCtrl($scope, $http, $translate, Wallet) {
       $scope.refreshCaptcha();
       switch (res.data.initial_error) {
         case 'Captcha Code Incorrect':
-          Wallet.displayError($translate.instant('CAPTCHA_INCORRECT'));
+          Alerts.displayError($translate.instant('CAPTCHA_INCORRECT'));
           break;
         case 'Quota Exceeded':
-          Wallet.displayError($translate.instant('QUOTA_EXCEEDED'));
+          Alerts.displayError($translate.instant('QUOTA_EXCEEDED'));
           break;
         default:
-          Wallet.displayError($translate.instant('UNKNOWN_ERROR'));
+          Alerts.displayError($translate.instant('UNKNOWN_ERROR'));
       }
     };
     let httpOptions = {

--- a/assets/js/controllers/openLink.controller.js
+++ b/assets/js/controllers/openLink.controller.js
@@ -2,12 +2,12 @@ angular
   .module('walletApp')
   .controller("OpenLinkController", OpenLinkController);
 
-function OpenLinkController($scope, Wallet, $translate, $stateParams, $state) {
+function OpenLinkController($scope, Wallet, $translate, $stateParams, $state, Alerts) {
   const paymentRequest = Wallet.parsePaymentRequest($stateParams.uri);
   Wallet.goal.send = paymentRequest;
   if (!Wallet.status.isLoggedIn) {
     $translate("PLEASE_LOGIN_FIRST").then(translation => {
-      Wallet.displayInfo(translation, true);
+      Alerts.displayInfo(translation, true);
     });
     $state.go("public.login");
   }

--- a/assets/js/controllers/recoverFunds.controller.js
+++ b/assets/js/controllers/recoverFunds.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('RecoverFundsCtrl', RecoverFundsCtrl);
 
-function RecoverFundsCtrl($scope, $rootScope, $state, $timeout, $translate, Wallet) {
+function RecoverFundsCtrl($scope, $rootScope, $state, $timeout, $translate, Wallet, Alerts) {
   $scope.isValidMnemonic = Wallet.isValidBIP39Mnemonic;
   $scope.currentStep = 1;
   $scope.fields = {
@@ -23,7 +23,7 @@ function RecoverFundsCtrl($scope, $rootScope, $state, $timeout, $translate, Wall
       $rootScope.$safeApply();
 
       const loginSuccess = () => {
-        Wallet.displaySuccess('Successfully recovered wallet!');
+        Alerts.displaySuccess('Successfully recovered wallet!');
       };
       const loginError = (err) => {
         console.error(err);
@@ -39,7 +39,7 @@ function RecoverFundsCtrl($scope, $rootScope, $state, $timeout, $translate, Wall
     const error = (err) => {
       $scope.working = false;
       let message = err || $translate.instant('RECOVERY_ERROR');
-      Wallet.displayError(message);
+      Alerts.displayError(message);
     };
 
     Wallet.my.recoverFromMnemonic(

--- a/assets/js/controllers/request.controller.js
+++ b/assets/js/controllers/request.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller("RequestCtrl", RequestCtrl);
 
-function RequestCtrl($scope, Wallet, $modalInstance, $log, destination, $translate, $stateParams, filterFilter, $filter) {
+function RequestCtrl($scope, Wallet, Alerts, $modalInstance, $log, destination, $translate, $stateParams, filterFilter, $filter) {
   $scope.status = Wallet.status;
   $scope.settings = Wallet.settings;
   $scope.accounts = Wallet.accounts;
@@ -52,7 +52,7 @@ function RequestCtrl($scope, Wallet, $modalInstance, $log, destination, $transla
   };
 
   $scope.closeAlert = alert => {
-    Wallet.closeAlert(alert);
+    Alerts.close(alert);
   };
 
   $scope.advancedReceive = () => {
@@ -65,7 +65,7 @@ function RequestCtrl($scope, Wallet, $modalInstance, $log, destination, $transla
   }
 
   $scope.done = () => {
-    Wallet.clearAlerts();
+    Alerts.clear();
 
     if($scope.fields.label == "" || $scope.fields.to.index == undefined) {
         $modalInstance.dismiss("");

--- a/assets/js/controllers/secondPassword.controller.js
+++ b/assets/js/controllers/secondPassword.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller("SecondPasswordCtrl", SecondPasswordCtrl);
 
-function SecondPasswordCtrl($scope, $log, Wallet, $modalInstance, $translate, insist, defer) {
+function SecondPasswordCtrl($scope, $log, Wallet, Alerts, $modalInstance, $translate, insist, defer) {
   $scope.insist = insist ? true : false;
   $scope.alerts = [];
   $scope.busy = false;
@@ -10,14 +10,14 @@ function SecondPasswordCtrl($scope, $log, Wallet, $modalInstance, $translate, in
 
   $scope.cancel = () => {
     defer.reject($translate.instant('SECOND_PASSWORD_CANCEL'));
-    Wallet.clearAlerts($scope.alerts);
+    Alerts.clear($scope.alerts);
     $modalInstance.dismiss("");
   };
 
   $scope.submit = () => {
     if ($scope.busy) return;
     $scope.busy = true;
-    Wallet.clearAlerts($scope.alerts);
+    Alerts.clear($scope.alerts);
     if (Wallet.validateSecondPassword($scope.secondPassword)) {
       $scope.busy = false;
       defer.resolve($scope.secondPassword);
@@ -25,7 +25,7 @@ function SecondPasswordCtrl($scope, $log, Wallet, $modalInstance, $translate, in
     } else {
       $scope.busy = false;
       $translate("SECOND_PASSWORD_INCORRECT").then(translation => {
-        Wallet.displayError(translation, false, $scope.alerts);
+        Alerts.displayError(translation, false, $scope.alerts);
       });
     }
   };

--- a/assets/js/controllers/send.controller.js
+++ b/assets/js/controllers/send.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller("SendCtrl", SendCtrl);
 
-function SendCtrl($scope, $log, Wallet, $modalInstance, $timeout, $state, $filter, $stateParams, $translate, paymentRequest, filterFilter, $uibModal) {
+function SendCtrl($scope, $log, Wallet, Alerts, $modalInstance, $timeout, $state, $filter, $stateParams, $translate, paymentRequest, filterFilter, $uibModal) {
 
   $scope.legacyAddresses = Wallet.legacyAddresses;
   $scope.accounts = Wallet.accounts;
@@ -68,7 +68,7 @@ function SendCtrl($scope, $log, Wallet, $modalInstance, $timeout, $state, $filte
 
   $scope.onError = (error) => {
     $translate("CAMERA_PERMISSION_DENIED").then(translation => {
-      Wallet.displayWarning(translation, false, $scope.alerts);
+      Alerts.displayWarning(translation, false, $scope.alerts);
     });
   };
 
@@ -98,7 +98,7 @@ function SendCtrl($scope, $log, Wallet, $modalInstance, $timeout, $state, $filte
       $scope.cameraOff();
     } else {
       $translate("QR_CODE_NOT_BITCOIN").then(translation => {
-        Wallet.displayWarning(translation, false, $scope.alerts);
+        Alerts.displayWarning(translation, false, $scope.alerts);
       });
       $log.error("Not a bitcoin QR code:" + url);
     }
@@ -117,7 +117,7 @@ function SendCtrl($scope, $log, Wallet, $modalInstance, $timeout, $state, $filte
   };
 
   $scope.close = () => {
-    Wallet.clearAlerts();
+    Alerts.clear($scope.alerts);
     $modalInstance.dismiss("");
   };
 
@@ -162,7 +162,7 @@ function SendCtrl($scope, $log, Wallet, $modalInstance, $timeout, $state, $filte
     $scope.sending = true;
     $scope.transaction.note = $scope.transaction.note.trim();
 
-    Wallet.clearAlerts();
+    Alerts.clear($scope.alerts);
 
     if ($scope.transaction.publicNote) {
       $scope.payment.note($scope.transaction.note);
@@ -172,7 +172,7 @@ function SendCtrl($scope, $log, Wallet, $modalInstance, $timeout, $state, $filte
       $scope.sending = false;
       if (message) {
         $translate(message).then(t => {
-          Wallet.displayError(t, false, $scope.alerts);
+          Alerts.displayError(t, false, $scope.alerts);
         });
       }
     };
@@ -217,7 +217,7 @@ function SendCtrl($scope, $log, Wallet, $modalInstance, $timeout, $state, $filte
   };
 
   $scope.closeAlert = (alert) => {
-    Wallet.closeAlert(alert);
+    Alerts.close(alert);
   };
 
   $scope.allowedDecimals = (currency) => {
@@ -370,7 +370,7 @@ function SendCtrl($scope, $log, Wallet, $modalInstance, $timeout, $state, $filte
       .catch(response => {
         let msg = response.error.message || response.error;
         $scope.backToForm();
-        Wallet.displayError(msg, false, $scope.alerts);
+        Alerts.displayError(msg, false, $scope.alerts);
         $scope.$root.$safeApply($scope);
       });
   };

--- a/assets/js/controllers/settings/accounts.controller.js
+++ b/assets/js/controllers/settings/accounts.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller("SettingsAccountsController", SettingsAccountsController);
 
-function SettingsAccountsController($scope, Wallet, $uibModal, filterFilter) {
+function SettingsAccountsController($scope, Wallet, Alerts, $uibModal, filterFilter) {
   $scope.accounts = Wallet.accounts;
   $scope.display = {
     archived: false
@@ -15,7 +15,7 @@ function SettingsAccountsController($scope, Wallet, $uibModal, filterFilter) {
   $scope.getLegacyTotal = () => Wallet.total('imported');
 
   $scope.newAccount = () => {
-    Wallet.clearAlerts();
+    Alerts.clear();
     let modalInstance = $uibModal.open({
       templateUrl: "partials/account-form.jade",
       controller: "AccountFormCtrl",
@@ -32,7 +32,7 @@ function SettingsAccountsController($scope, Wallet, $uibModal, filterFilter) {
   };
 
   $scope.editAccount = (account) => {
-    Wallet.clearAlerts();
+    Alerts.clear();
     let modalInstance = $uibModal.open({
       templateUrl: "partials/account-form.jade",
       controller: "AccountFormCtrl",

--- a/assets/js/controllers/settings/addressImport.controller.js
+++ b/assets/js/controllers/settings/addressImport.controller.js
@@ -2,10 +2,10 @@ angular
   .module('walletApp')
   .controller("AddressImportCtrl", AddressImportCtrl);
 
-function AddressImportCtrl($scope, $log, Wallet, $modalInstance, $translate, $state, $timeout) {
+function AddressImportCtrl($scope, $log, Wallet, Alerts, $modalInstance, $translate, $state, $timeout) {
   $scope.settings = Wallet.settings;
   $scope.accounts = Wallet.accounts;
-  $scope.alerts = Wallet.alerts;
+  $scope.alerts = Alerts.alerts;
   $scope.address = null;
   $scope.step = 1;
   $scope.BIP38 = false;
@@ -94,7 +94,7 @@ function AddressImportCtrl($scope, $log, Wallet, $modalInstance, $translate, $st
     const error = (error) => {
       $scope.status.sweeping = false;
       if (error && typeof error === 'string') {
-        Wallet.displayError(error);
+        Alerts.displayError(error);
       }
       $scope.$root.$safeApply($scope);
     };
@@ -119,7 +119,7 @@ function AddressImportCtrl($scope, $log, Wallet, $modalInstance, $translate, $st
 
   $scope.onError = (error) => {
     $translate("CAMERA_PERMISSION_DENIED").then(function(translation) {
-      Wallet.displayWarning(translation);
+      Alerts.displayWarning(translation);
     });
   };
 

--- a/assets/js/controllers/settings/changePassword.controller.js
+++ b/assets/js/controllers/settings/changePassword.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller("ChangePasswordCtrl", ChangePasswordCtrl);
 
-function ChangePasswordCtrl($scope, $log, Wallet, $modalInstance, $translate) {
+function ChangePasswordCtrl($scope, $log, Wallet, Alerts, $modalInstance, $translate) {
   $scope.isCorrectMainPassword = Wallet.isCorrectMainPassword;
   $scope.uid = Wallet.user.uid;
 
@@ -33,7 +33,7 @@ function ChangePasswordCtrl($scope, $log, Wallet, $modalInstance, $translate) {
   };
 
   $scope.close = () => {
-    Wallet.clearAlerts();
+    Alerts.clear();
     $modalInstance.dismiss("");
   };
 

--- a/assets/js/controllers/settings/importedAddresses.controller.js
+++ b/assets/js/controllers/settings/importedAddresses.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller("SettingsImportedAddressesCtrl", SettingsImportedAddressesCtrl);
 
-function SettingsImportedAddressesCtrl($scope, Wallet, $translate, $uibModal) {
+function SettingsImportedAddressesCtrl($scope, Wallet, Alerts, $translate, $uibModal) {
   $scope.legacyAddresses = Wallet.legacyAddresses;
   $scope.display = {
     archived: false,
@@ -26,7 +26,7 @@ function SettingsImportedAddressesCtrl($scope, Wallet, $translate, $uibModal) {
   };
 
   $scope.importAddress = () => {
-    Wallet.clearAlerts();
+    Alerts.clear();
     let modalInstance = $uibModal.open({
       templateUrl: "partials/settings/import-address.jade",
       controller: "AddressImportCtrl",

--- a/assets/js/controllers/settings/info.controller.js
+++ b/assets/js/controllers/settings/info.controller.js
@@ -2,9 +2,9 @@ angular
   .module('walletApp')
   .controller("SettingsInfoCtrl", SettingsInfoCtrl);
 
-function SettingsInfoCtrl($scope, Wallet, $translate, $window) {
+function SettingsInfoCtrl($scope, Wallet, Alerts, $translate, $window) {
   $scope.uid = Wallet.user.uid;
-  
+
   $scope.display = {
     pairingCode: false
   };
@@ -22,7 +22,7 @@ function SettingsInfoCtrl($scope, Wallet, $translate, $window) {
       $scope.display.pairingCode = true;
     };
     const error = () => {
-      Wallet.displayError("Failed to load pairing code.");
+      Alerts.displayError("Failed to load pairing code.");
       $scope.loading = false;
     };
     $scope.loading = true;

--- a/assets/js/controllers/settings/preferences.controller.js
+++ b/assets/js/controllers/settings/preferences.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller("SettingsPreferencesCtrl", SettingsPreferencesCtrl);
 
-function SettingsPreferencesCtrl($scope, Wallet, $uibModal, $filter, $translate, $window) {
+function SettingsPreferencesCtrl($scope, Wallet, Alerts, $uibModal, $filter, $translate, $window) {
   $scope.user = Wallet.user;
   $scope.settings = Wallet.settings;
   $scope.languages = Wallet.languages;
@@ -21,7 +21,7 @@ function SettingsPreferencesCtrl($scope, Wallet, $uibModal, $filter, $translate,
   $scope.changeEmail = (email, success, error) => {
     Wallet.changeEmail(email, success, error);
   };
-  
+
   $scope.setHandleBitcoinLinks = () => {
     Wallet.handleBitcoinLinks();
   };
@@ -52,17 +52,17 @@ function SettingsPreferencesCtrl($scope, Wallet, $uibModal, $filter, $translate,
 
   $scope.changeLogoutTime = (m, success, errorCallback) => {
     const error = () => {
-      Wallet.displayError("Failed to update auto logout time");
+      Alerts.displayError("Failed to update auto logout time");
       errorCallback();
     };
     Wallet.setLogoutTime(m, success, error);
   };
-  
+
   $scope.validateFee = (candidate) => {
     let n = parseInt(candidate);
     return !isNaN(candidate) && n > 0 && n <= 1000000;
   };
-  
+
   $scope.validateLogoutTime = (candidate) => {
     let n = parseInt(candidate);
     return !isNaN(candidate) && n >= 1 && n <= 1440;

--- a/assets/js/controllers/settings/recovery.controller.js
+++ b/assets/js/controllers/settings/recovery.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller("RecoveryCtrl", RecoveryCtrl);
 
-function RecoveryCtrl($scope, Wallet, $state, $translate) {
+function RecoveryCtrl($scope, Wallet, Alerts, $state, $translate) {
   $scope.status = Wallet.status;
   $scope.isValidMnemonic = Wallet.isValidBIP39Mnemonic;
 
@@ -39,12 +39,12 @@ function RecoveryCtrl($scope, Wallet, $state, $translate) {
       $state.go("wallet.common.transactions", {
         accountIndex: ""
       });
-      Wallet.displaySuccess("Successfully imported seed");
+      Alerts.displaySuccess("Successfully imported seed");
     };
 
     const error = (message) => {
       $scope.importing = false;
-      Wallet.displayError(message);
+      Alerts.displayError(message);
     };
 
     const cancel = () => {
@@ -60,7 +60,7 @@ function RecoveryCtrl($scope, Wallet, $state, $translate) {
   $scope.doNotCopyPaste = (event) => {
     event.preventDefault();
     $translate("DO_NOT_COPY_PASTE").then((translation) => {
-      Wallet.displayWarning(translation);
+      Alerts.displayWarning(translation);
     });
   };
 

--- a/assets/js/controllers/settings/security.controller.js
+++ b/assets/js/controllers/settings/security.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller("SettingsSecurityCtrl", SettingsSecurityCtrl);
 
-function SettingsSecurityCtrl($scope, Wallet, $uibModal, $translate) {
+function SettingsSecurityCtrl($scope, Wallet, Alerts, $uibModal, $translate) {
   $scope.settings = Wallet.settings;
   $scope.btc = Wallet.btcCurrencies[0];
   $scope.processToggleRememberTwoFactor = null;
@@ -67,7 +67,7 @@ function SettingsSecurityCtrl($scope, Wallet, $uibModal, $translate) {
 
   $scope.changeIpWhitelist = (list, success, errorCallback) => {
     const error = () => {
-      Wallet.displayError("Failed to update IP whitelist");
+      Alerts.displayError("Failed to update IP whitelist");
       errorCallback();
     };
     Wallet.setIPWhitelist(list, success, error);
@@ -81,7 +81,7 @@ function SettingsSecurityCtrl($scope, Wallet, $uibModal, $translate) {
 
   $scope.changePbkdf2 = (n, successCallback, errorCallback) => {
     const error = () => {
-      Wallet.displayError("Failed to update PBKDF2 iterations");
+      Alerts.displayError("Failed to update PBKDF2 iterations");
       errorCallback();
     };
     Wallet.setPbkdf2Iterations(n, successCallback, error, errorCallback);

--- a/assets/js/controllers/settings/setSecondPassword.controller.js
+++ b/assets/js/controllers/settings/setSecondPassword.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller("SetSecondPasswordCtrl", SetSecondPasswordCtrl);
 
-function SetSecondPasswordCtrl($scope, $log, Wallet, $modalInstance, $translate, $timeout) {
+function SetSecondPasswordCtrl($scope, $log, Wallet, Alerts, $modalInstance, $translate, $timeout) {
   $scope.isValid = false;
   $scope.busy = null;
   $scope.fields = {
@@ -11,7 +11,7 @@ function SetSecondPasswordCtrl($scope, $log, Wallet, $modalInstance, $translate,
   };
 
   $scope.close = () => {
-    Wallet.clearAlerts();
+    Alerts.clear();
     $modalInstance.dismiss("");
   };
 

--- a/assets/js/controllers/settings/settings.controller.js
+++ b/assets/js/controllers/settings/settings.controller.js
@@ -2,13 +2,13 @@ angular
   .module('walletApp')
   .controller("SettingsCtrl", SettingsCtrl);
 
-function SettingsCtrl($scope, Wallet, $cookieStore, $state) {
+function SettingsCtrl($scope, Wallet, Alerts, $cookieStore, $state) {
   if ($state.current.name === "wallet.common.settings") {
     $state.go("wallet.common.settings.info");
   }
 
   $scope.didLoad = () => {
-    Wallet.clearAlerts();
+    Alerts.clear();
     $scope.status = Wallet.status;
   };
 

--- a/assets/js/controllers/settings/showPrivateKey.controller.js
+++ b/assets/js/controllers/settings/showPrivateKey.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('ShowPrivateKeyCtrl', ShowPrivateKeyCtrl);
 
-function ShowPrivateKeyCtrl($scope, $log, Wallet, $modalInstance, $timeout, $translate, addressObj) {
+function ShowPrivateKeyCtrl($scope, $log, Wallet, Alerts, $modalInstance, $timeout, $translate, addressObj) {
   $scope.settings = Wallet.settings;
   $scope.accessAllowed = false;
   $scope.address = addressObj.address;
@@ -17,7 +17,7 @@ function ShowPrivateKeyCtrl($scope, $log, Wallet, $modalInstance, $timeout, $tra
   };
 
   $scope.close = () => {
-    Wallet.clearAlerts();
+    Alerts.clear();
     $modalInstance.dismiss('');
   };
 

--- a/assets/js/controllers/settings/twoFactor.controller.js
+++ b/assets/js/controllers/settings/twoFactor.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller("TwoFactorCtrl", TwoFactorCtrl);
 
-function TwoFactorCtrl($scope, Wallet, $modalInstance, $translate, $timeout) {
+function TwoFactorCtrl($scope, Wallet, Alerts, $modalInstance, $translate, $timeout) {
   $scope.settings = Wallet.settings;
   $scope.user = Wallet.user;
 
@@ -23,7 +23,7 @@ function TwoFactorCtrl($scope, Wallet, $modalInstance, $translate, $timeout) {
   $scope.alerts = [];
 
   $scope.closeAlert = (alert) => {
-    $scope.alerts.splice($scope.alerts.indexOf(alert));
+    Alerts.close(alert, $scope.alerts);
   };
 
   $scope.displayConfirmationError = () => {
@@ -128,7 +128,7 @@ function TwoFactorCtrl($scope, Wallet, $modalInstance, $translate, $timeout) {
   };
 
   $scope.close = () => {
-    Wallet.clearAlerts();
+    Alerts.clear();
     $modalInstance.dismiss("");
   };
 

--- a/assets/js/controllers/signup.controller.js
+++ b/assets/js/controllers/signup.controller.js
@@ -2,12 +2,12 @@ angular
   .module('walletApp')
   .controller("SignupCtrl", SignupCtrl);
 
-function SignupCtrl($scope, $rootScope, $log, Wallet, $uibModal, $translate, $cookieStore, $filter, $state, $http) {
+function SignupCtrl($scope, $rootScope, $log, Wallet, Alerts, $uibModal, $translate, $cookieStore, $filter, $state, $http) {
   $scope.currentStep = 1;
   $scope.working = false;
   $scope.languages = Wallet.languages;
   $scope.currencies = Wallet.currencies;
-  $scope.alerts = Wallet.alerts;
+  $scope.alerts = Alerts.alerts;
   $scope.status = Wallet.status;
 
   $scope.$watch("status.isLoggedIn", newValue => {
@@ -47,7 +47,7 @@ function SignupCtrl($scope, $rootScope, $log, Wallet, $uibModal, $translate, $co
   };
 
   $scope.close = () => {
-    Wallet.clearAlerts();
+    Alerts.clear();
     $state.go("wallet.common.home");
   };
 

--- a/assets/js/controllers/walletNavigation.controller.js
+++ b/assets/js/controllers/walletNavigation.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('WalletNavigationCtrl', WalletNavigationCtrl);
 
-function WalletNavigationCtrl($scope, Wallet, SecurityCenter, $state, $stateParams, $uibModal, filterFilter, $location) {
+function WalletNavigationCtrl($scope, Wallet, Alerts, SecurityCenter, $state, $stateParams, $uibModal, filterFilter, $location) {
   $scope.status = Wallet.status;
   $scope.total = Wallet.total;
   $scope.settings = Wallet.settings;
@@ -44,7 +44,7 @@ function WalletNavigationCtrl($scope, Wallet, SecurityCenter, $state, $statePara
   };
 
   $scope.newAccount = () => {
-    Wallet.clearAlerts();
+    Alerts.clear();
     let modalInstance = $uibModal.open({
       templateUrl: 'partials/account-form.jade',
       controller: 'AccountFormCtrl',

--- a/assets/js/services/alerts.service.js
+++ b/assets/js/services/alerts.service.js
@@ -1,0 +1,38 @@
+angular
+  .module('walletApp')
+  .factory('Alerts', Alerts);
+
+Alerts.$inject = ['$timeout'];
+
+function Alerts($timeout) {
+  const service = {
+    alerts          : [],
+    close           : close,
+    clear           : clear,
+    displayInfo     : display.bind(null, 'info'),
+    displaySuccess  : display.bind(null, 'success'),
+    displayWarning  : display.bind(null, ''),
+    displayError    : display.bind(null, 'danger'),
+    displayReceivedBitcoin : display.bind(null, 'received-bitcoin')
+  };
+
+  function close(alert, context=service.alerts) {
+    $timeout.cancel(alert.timer);
+    context.splice(context.indexOf(alert), 1);
+  }
+
+  function clear(context=service.alerts) {
+    while (context.length > 0) {
+      let alert = context.pop();
+      $timeout.cancel(alert.timer);
+    }
+  }
+
+  function display(type, message, keep=false, context=service.alerts) {
+    let alert = { type: type, msg: message };
+    if (!keep) alert.timer = $timeout(() => close(alert), 7000);
+    context.push(alert);
+  }
+
+  return service;
+}

--- a/tests/controllers/request_ctrl_spec.coffee
+++ b/tests/controllers/request_ctrl_spec.coffee
@@ -105,10 +105,10 @@ describe "RequestCtrl", ->
       expect(foundAccount).toBe(true)
       expect(foundLegacyAddress).toBe(true)
 
-    it "should close", inject((Wallet) ->
-      spyOn(Wallet, "clearAlerts")
+    it "should close", inject((Alerts) ->
+      spyOn(Alerts, "clear")
       scope.done()
-      expect(Wallet.clearAlerts).toHaveBeenCalled()
+      expect(Alerts.clear).toHaveBeenCalled()
     )
 
     it "should show a payment request address when legacy address is selected", inject(()->

--- a/tests/controllers/second_password_ctrl_spec.coffee
+++ b/tests/controllers/second_password_ctrl_spec.coffee
@@ -33,10 +33,10 @@ describe "SecondPasswordCtrl", ->
 
     return
 
-  it "should clear alerts", inject((Wallet) ->
-    spyOn(Wallet, "clearAlerts")
+  it "should clear alerts", inject((Alerts) ->
+    spyOn(Alerts, "clear")
     scope.cancel()
-    expect(Wallet.clearAlerts).toHaveBeenCalled()
+    expect(Alerts.clear).toHaveBeenCalled()
   )
 
   it "should close the modal when password is correct", ->

--- a/tests/controllers/send_ctrl_spec.coffee
+++ b/tests/controllers/send_ctrl_spec.coffee
@@ -111,9 +111,6 @@ describe "SendCtrl", ->
       it "should load wallet settings", ->
         expect(scope.settings).toBeDefined()
 
-      it "should load wallet alerts", ->
-        expect(scope.alerts).toEqual(Wallet.alerts)
-
       it "should know the users fiat currency", ->
         expect(scope.fiatCurrency.code).toEqual('USD')
 
@@ -360,14 +357,14 @@ describe "SendCtrl", ->
           scope.payment = new Wallet.payment(true)
           askForSecondPassword.resolve()
 
-        it "should display an error when process fails", inject((Wallet) ->
-          spyOn(Wallet, 'displayError').and.callThrough()
+        it "should display an error when process fails", inject((Alerts) ->
+          spyOn(Alerts, 'displayError').and.callThrough()
           expect(scope.alerts.length).toEqual(0)
           scope.send()
           scope.$digest()
           expect(scope.alerts.length).toEqual(1)
-          expect(Wallet.displayError).toHaveBeenCalled()
-          expect(Wallet.displayError.calls.argsFor(0)[0]).toEqual('err_message')
+          expect(Alerts.displayError).toHaveBeenCalled()
+          expect(Alerts.displayError.calls.argsFor(0)[0]).toEqual('err_message')
         )
 
       describe "success", ->
@@ -393,11 +390,11 @@ describe "SendCtrl", ->
           expect(Wallet.beep).toHaveBeenCalled()
         )
 
-        it "should clear alerts", inject((Wallet) ->
-          spyOn(Wallet, 'clearAlerts')
+        it "should clear alerts", inject((Alerts) ->
+          spyOn(Alerts, 'clear')
           scope.send()
           scope.$digest()
-          expect(Wallet.clearAlerts).toHaveBeenCalled()
+          expect(Alerts.clear).toHaveBeenCalled()
         )
 
         it "should show a confirmation modal", inject(($uibModal)->

--- a/tests/controllers/settings_change_password_ctrl_spec.coffee
+++ b/tests/controllers/settings_change_password_ctrl_spec.coffee
@@ -13,9 +13,9 @@ describe "ChangePasswordCtrl", ->
   beforeEach ->
     angular.mock.inject ($injector, $rootScope, $controller, $compile) ->
       Wallet = $injector.get("Wallet")
-      
+
       Wallet.user = {uid: "12345678-1234-1234-1234-1234567890ab"}
-      
+
       spyOn(Wallet, "isCorrectMainPassword").and.callFake((pwd) ->
         return pwd != "wrong"
       )
@@ -43,10 +43,10 @@ describe "ChangePasswordCtrl", ->
 
     return
 
-  it "should be able to close", inject((Wallet) ->
-    spyOn(Wallet, "clearAlerts")
+  it "should be able to close", inject((Alerts) ->
+    spyOn(Alerts, "clear")
     scope.close()
-    expect(Wallet.clearAlerts).toHaveBeenCalled()
+    expect(Alerts.clear).toHaveBeenCalled()
   )
 
   it "should get model values from the form", (() ->

--- a/tests/controllers/settings_info_ctrl_spec.coffee
+++ b/tests/controllers/settings_info_ctrl_spec.coffee
@@ -22,15 +22,15 @@ describe "SettingsInfoCtrl", ->
       return
 
     return
-    
-  it "should show pairing code", inject((Wallet) ->
+
+  it "should show pairing code", inject((Wallet, Alerts) ->
     spyOn(Wallet, "makePairingCode")
-    spyOn(Wallet, "displayError")
+    spyOn(Alerts, "displayError")
 
     scope.showPairingCode()
 
     expect(Wallet.makePairingCode).toHaveBeenCalled()
-    expect(Wallet.displayError).not.toHaveBeenCalled()
+    expect(Alerts.displayError).not.toHaveBeenCalled()
 
     return
   )

--- a/tests/controllers/settings_security_ctrl_spec.coffee
+++ b/tests/controllers/settings_security_ctrl_spec.coffee
@@ -41,19 +41,19 @@ describe "SettingsSecurityCtrl", ->
     expect(scope.settings).toBe(Wallet.settings)
     return
   )
-  
+
   describe "pbkdf2", ->
 
     it "should be valid Pbkdf2", ->
       expect(scope.validatePbkdf2(1)).toBe(true)
       expect(scope.validatePbkdf2(0)).toBe(false)
 
-    it "can set Pbkdf2", inject((Wallet) ->
+    it "can set Pbkdf2", inject((Wallet, Alerts) ->
       spyOn(Wallet, "setPbkdf2Iterations")
-      spyOn(Wallet, "displayError")
+      spyOn(Alerts, "displayError")
       scope.changePbkdf2(10)
       expect(Wallet.setPbkdf2Iterations).toHaveBeenCalled()
-      expect(Wallet.displayError).not.toHaveBeenCalled()
+      expect(Alerts.displayError).not.toHaveBeenCalled()
 
       return
     )
@@ -140,12 +140,12 @@ describe "SettingsSecurityCtrl", ->
       it "should allow an empty list", ->
         expect(scope.validateIpWhitelist('')).toBe(true)
 
-    it "can change IP whitelist", inject((Wallet) ->
+    it "can change IP whitelist", inject((Wallet, Alerts) ->
       spyOn(Wallet, "setIPWhitelist")
-      spyOn(Wallet, "displayError")
+      spyOn(Alerts, "displayError")
       scope.changeIpWhitelist([])
       expect(Wallet.setIPWhitelist).toHaveBeenCalled()
-      expect(Wallet.displayError).not.toHaveBeenCalled()
+      expect(Alerts.displayError).not.toHaveBeenCalled()
 
       return
     )

--- a/tests/controllers/settings_set_second_password_ctrl_spec.coffee
+++ b/tests/controllers/settings_set_second_password_ctrl_spec.coffee
@@ -24,10 +24,10 @@ describe "SetSecondPasswordCtrl", ->
 
     return
 
-  it "should close", inject((Wallet) ->
-    spyOn(Wallet, "clearAlerts")
+  it "should close", inject((Alerts) ->
+    spyOn(Alerts, "clear")
     scope.close()
-    expect(Wallet.clearAlerts).toHaveBeenCalled()
+    expect(Alerts.clear).toHaveBeenCalled()
   )
 
   it "cover setSecondPassword", ->

--- a/tests/controllers/settings_settings_ctrl_spec.coffee
+++ b/tests/controllers/settings_settings_ctrl_spec.coffee
@@ -21,10 +21,10 @@ describe "SettingsCtrl", ->
 
     return
 
-  it "should load", inject((Wallet) ->
-    spyOn(Wallet, "clearAlerts")
+  it "should load", inject((Wallet, Alerts) ->
+    spyOn(Alerts, "clear")
     scope.didLoad()
-    expect(Wallet.clearAlerts).toHaveBeenCalled()
+    expect(Alerts.clear).toHaveBeenCalled()
     expect(scope.status).toBe(Wallet.status)
     return
   )

--- a/tests/controllers/signup_controller_spec.coffee
+++ b/tests/controllers/signup_controller_spec.coffee
@@ -40,10 +40,10 @@ describe "SignupCtrl", ->
 
     return
 
-  it "should close", inject((Wallet) ->
-    spyOn(Wallet, "clearAlerts")
+  it "should close", inject((Alerts) ->
+    spyOn(Alerts, "clear")
     scope.close()
-    expect(Wallet.clearAlerts).toHaveBeenCalled()
+    expect(Alerts.clear).toHaveBeenCalled()
   )
 
   describe "first step", ->

--- a/tests/services/wallet_service_spec.coffee
+++ b/tests/services/wallet_service_spec.coffee
@@ -1,5 +1,6 @@
 describe "walletServices", () ->
   Wallet = undefined
+  Alerts = undefined
   mockObserver = undefined
   errors = undefined
   MyBlockchainSettings = undefined
@@ -12,6 +13,7 @@ describe "walletServices", () ->
 
       Wallet = $injector.get("Wallet")
       MyBlockchainSettings = $injector.get("MyBlockchainSettings")
+      Alerts = $injector.get('Alerts')
 
       spyOn(Wallet,"monitor").and.callThrough()
 
@@ -66,19 +68,6 @@ describe "walletServices", () ->
       Wallet.monitor("on_tx")
       expect(ngAudio.load).toHaveBeenCalled()
     )
-
-  describe "alerts()", ->
-
-    it "should should remove alert after some time", inject((Wallet, $timeout) ->
-      Wallet.displaySuccess("Victory")
-      expect(Wallet.alerts.length).toBe(1)
-      $timeout.flush()
-      expect(Wallet.alerts.length).toBe(0)
-
-
-    )
-    return
-
 
   describe "language", ->
 
@@ -433,37 +422,31 @@ describe "walletServices", () ->
       expect(callbacks.needsBip38).toHaveBeenCalled()
     )
 
-  describe "displayReceivedBitcoin()", ->
-    it "should display an alert", ->
-      spyOn(Wallet, "displayAlert")
-      Wallet.displayReceivedBitcoin()
-      expect(Wallet.displayAlert).toHaveBeenCalled()
-
   describe "notifications", ->
     describe "on_tx", ->
       beforeEach ->
-        spyOn(Wallet, "displayReceivedBitcoin")
+        spyOn(Alerts, "displayReceivedBitcoin")
 
       it "should display a message if the user received bitcoin", ->
         spyOn(Wallet, "updateTransactions").and.callFake () ->
           Wallet.transactions.push {result: 1}
 
         Wallet.monitor("on_tx")
-        expect(Wallet.displayReceivedBitcoin).toHaveBeenCalled()
+        expect(Alerts.displayReceivedBitcoin).toHaveBeenCalled()
 
       it "should not display a message if the user spent bitcoin", ->
         spyOn(Wallet, "updateTransactions").and.callFake () ->
           Wallet.transactions.push {result: -1}
 
         Wallet.monitor("on_tx")
-        expect(Wallet.displayReceivedBitcoin).not.toHaveBeenCalled()
+        expect(Alerts.displayReceivedBitcoin).not.toHaveBeenCalled()
 
       it "should not display a message if the user moved bitcoin between accounts", ->
         spyOn(Wallet, "updateTransactions").and.callFake () ->
           Wallet.transactions.push {result: 1, intraWallet: true}
 
         Wallet.monitor("on_tx")
-        expect(Wallet.displayReceivedBitcoin).not.toHaveBeenCalled()
+        expect(Alerts.displayReceivedBitcoin).not.toHaveBeenCalled()
 
   describe "fetchMoreTransactions()", ->
     beforeEach ->


### PR DESCRIPTION
Fairly straightforward change, but it's a good first step towards splitting up Wallet service. Alerts are now managed in their own service, with almost the same api as when Wallet had control over alerts.