### PR TITLE
feat(send): keep from field and hide account dropdown with single account

### DIFF
--- a/app/partials/send.jade
+++ b/app/partials/send.jade
@@ -17,29 +17,32 @@
   div(ng-hide="confirmationStep")
     form.ph-form(role="form",name="sendForm",novalidate)
       //- From
-      .form-group.row(ng-show="numberOfActiveAccountsAndLegacyAddresses() > 1")
-        label.col-sm-2.col-xs-12
+      .form-group.row
+        label.pts.col-sm-2.col-xs-12
           span(translate="FROM:")
         .col-sm-10.col-xs-12(ng-class="{'has-error': (sendForm.from.$invalid && sendForm.destinations0.$touched) || (!amountIsValid && (sendForm.amounts0.$touched || sendForm.amountsFiat0.$touched))}")
-          p.form-control-static(ng-hide="originsLoaded")
-            img(src="img/spinner.gif")
-          span(ng-show="originsLoaded")
-            ui-select(
-              ng-model="transaction.from"
-              name="from"
-              ng-change="validateAmounts(); checkForSameDestination(); setPaymentFrom()"
-              required)
-              ui-select-match
-                label-origin(origin="$select.selected")
-              ui-select-choices(repeat="origin in origins | filter: getFilter($select.search)" group-by="'type'" ui-disable-choice="hasZeroBalance(origin)")
-                span(ng-class="{aaa: hasZeroBalance(origin)}")
-                  label-origin(origin='origin' highlight="$select.search")
+          .form-control(ng-show="numberOfActiveAccountsAndLegacyAddresses() <= 1")
+            | My Bitcoin Wallet
+          div(ng-show="numberOfActiveAccountsAndLegacyAddresses() > 1")
+            p.form-control-static(ng-hide="originsLoaded")
+              img(src="img/spinner.gif")
+            span(ng-show="originsLoaded")
+              ui-select(
+                ng-model="transaction.from"
+                name="from"
+                ng-change="validateAmounts(); checkForSameDestination(); setPaymentFrom()"
+                required)
+                ui-select-match
+                  label-origin(origin="$select.selected")
+                ui-select-choices(repeat="origin in origins | filter: getFilter($select.search)" group-by="'type'" ui-disable-choice="hasZeroBalance(origin)")
+                  span(ng-class="{aaa: hasZeroBalance(origin)}")
+                    label-origin(origin='origin' highlight="$select.search")
           span.help-block(translate="INSUFFICIENT" ng-show="!amountIsValid && (sendForm.amounts0.$touched || sendForm.amountsFiat0.$touched)")
           span.help-block(ng-show="sendForm.from.$invalid && sendForm.destinations0.$touched") Must select an account to send from
       //- Advanced Send
       .form-group.bc-modal-fade.mvl.advanced-recipient.row
         //- To
-        label.col-sm-2.col-xs-12
+        label.pts.col-sm-2.col-xs-12
           span(translate="TO:")
         .col-sm-10.col-xs-12
           .flex-column(ng-class="{'advanced-recipient-row': advanced}" ng-repeat="item in transaction.destinations track by $index")

--- a/app/partials/send.jade
+++ b/app/partials/send.jade
@@ -22,7 +22,7 @@
           span(translate="FROM:")
         .col-sm-10.col-xs-12(ng-class="{'has-error': (sendForm.from.$invalid && sendForm.destinations0.$touched) || (!amountIsValid && (sendForm.amounts0.$touched || sendForm.amountsFiat0.$touched))}")
           .form-control(ng-show="numberOfActiveAccountsAndLegacyAddresses() <= 1")
-            | My Bitcoin Wallet
+            | {{ transaction.from.label }}
           div(ng-show="numberOfActiveAccountsAndLegacyAddresses() > 1")
             p.form-control-static(ng-hide="originsLoaded")
               img(src="img/spinner.gif")

--- a/app/templates/destination-input.jade
+++ b/app/templates/destination-input.jade
@@ -18,10 +18,14 @@
     .input-group-btn(uib-dropdown)
       button#qr.btn.btn-default(
         type="button"
-        ng-if="browserWithCamera"
+        ng-disabled="!browserWithCamera"
+        ng-class="{ 'border-rounded-right': accounts.length <= 1 }"
         ng-click="onRequestQr()")
         img(src="img/qr-code.png" alt="QR")
-      button.btn.btn-default(type="button" uib-dropdown-toggle)
+      button.btn.btn-default(
+        type="button"
+        ng-show="accounts.length > 1"
+        uib-dropdown-toggle)
         span.caret
         span.sr-only Toggle Dropdown
       ul.uib-dropdown-menu.dropdown-menu-right.drop-menu

--- a/assets/css/modules/_destination-input.scss
+++ b/assets/css/modules/_destination-input.scss
@@ -10,6 +10,10 @@
     border: 1px solid $grey;
     border-radius: 5px 0px 0px 5px !important;
   }
+  .border-rounded-right {
+    border-bottom-right-radius: 5px !important;
+    border-top-right-radius: 5px !important;
+  }
   .btn-default { border-color: $grey; }
   .drop-menu {
     border-radius: 0px;

--- a/assets/js/controllers/send.controller.js
+++ b/assets/js/controllers/send.controller.js
@@ -152,7 +152,7 @@ function SendCtrl($scope, $log, Wallet, Alerts, $modalInstance, $timeout, $state
 
   $scope.numberOfActiveAccountsAndLegacyAddresses = () => {
     let numAccts = Wallet.accounts().filter(a => !a.archived).length;
-    let numAddrs = Wallet.legacyAddresses().filter(a => !a.archived).length;
+    let numAddrs = Wallet.legacyAddresses().filter(a => !a.archived && !a.isWatchOnly).length;
     return numAccts + numAddrs;
   };
 

--- a/tests/controllers/send_ctrl_spec.coffee
+++ b/tests/controllers/send_ctrl_spec.coffee
@@ -479,7 +479,7 @@ describe "SendCtrl", ->
 
       it "should return the correct amount", ->
         amount = scope.numberOfActiveAccountsAndLegacyAddresses()
-        expect(amount).toEqual(4)
+        expect(amount).toEqual(3)
 
     describe "hasZeroBalance", ->
 


### PR DESCRIPTION
When there is only one account:
* Keep the from field, this makes error messaging look nicer
* Hide the accounts dropdown menu (so user cannot try to send to self)