### PR TITLE
Support Chinese both as browser language and as setting

### DIFF
--- a/assets/js/controllers/signup.controller.js
+++ b/assets/js/controllers/signup.controller.js
@@ -16,7 +16,11 @@ function SignupCtrl($scope, $state, $cookies, $filter, $translate, $uibModal, Wa
     }
   });
 
-  let language_guess = $filter("getByProperty")("code", $translate.use(), languages);
+  let language_code = $translate.use();
+  if(language_code == "zh_CN") {
+    language_code = "zh-cn";
+  }
+  let language_guess = $filter("getByProperty")("code", language_code, languages);
   if (language_guess == null) {
     $scope.language_guess = $filter("getByProperty")("code", "en", languages);
   }

--- a/assets/js/services/bcTranslationLoader.service.js
+++ b/assets/js/services/bcTranslationLoader.service.js
@@ -17,6 +17,7 @@ function BCTranslateStaticFilesLoader($http, $q, $translateStaticFilesLoader) {
     bg: 'build/locales/bg.json',
     fr: 'build/locales/fr.json',
     zh_CN: 'build/locales/zh-cn.json',
+    "zh-cn": 'build/locales/zh-cn.json',
     hu: 'build/locales/hu.json',
     sl: 'build/locales/sl.json',
     id: 'build/locales/id.json',


### PR DESCRIPTION
It was not possible to switch to Chinese if the browser language was not Chinese. I believe I fixed it now so that:

1 - when the browser language is Chinese, the registration form guesses Chinese as the language and sets the correct setting
2 - if the browser language is English, the user can switch to Chinese

I only tried this with simplified chinese, not with traditional chinese.