### PR TITLE
Medium priority

### DIFF
--- a/app/partials/settings/change-password.jade
+++ b/app/partials/settings/change-password.jade
@@ -5,21 +5,42 @@
     .form-group(ng-class="{'has-error': passwordForm.currentPassword.$invalid && passwordForm.currentPassword.$touched && passwordForm.currentPassword.$dirty, 'has-success': passwordForm.currentPassword.$valid}")
       label.col-sm-4.control-label(translate="CURRENT_PASSWORD")
       .col-sm-8
-        input.form-control(type="password" name="currentPassword" ng-model="fields.currentPassword" is-valid="isCorrectMainPassword(fields.currentPassword)" required autofocus)
+        input.form-control(
+          type="password"
+          name="currentPassword"
+          ng-model="fields.currentPassword"
+          is-valid="isCorrectMainPassword(fields.currentPassword)"
+          required
+          autofocus)
         span.help-block(translate="INCORRECT" ng-show="passwordForm.currentPassword.$invalid && passwordForm.currentPassword.$touched && passwordForm.currentPassword.$dirty")
     .form-group(ng-class="{'has-error': passwordForm.password.$invalid && passwordForm.password.$touched && passwordForm.password.$dirty, 'has-success': passwordForm.password.$valid}")
       label.col-sm-4.control-label(translate="NEW_PASSWORD")
       .col-sm-8
-        input.form-control(type="password" name="password" ng-model="fields.password" ng-change="fields.confirmation = ''" min-entropy="25" ng-maxlength="255" is-valid="fields.password != uid" required)
+        input.form-control(
+          type="password"
+          name="password"
+          ng-model="fields.password"
+          ng-change="fields.confirmation = ''"
+          min-entropy="25"
+          ng-maxlength="255"
+          is-valid="fields.password != uid && !isUserEmail(fields.password)"
+          required)
         password-entropy(password="fields.password").help-block
         span(ng-show="passwordForm.password.$touched && passwordForm.password.$dirty")
           span.help-block(translate="TOO_WEAK" ng-show="passwordForm.password.$error.minEntropy && !passwordForm.password.$error.isValid")
           span.help-block(translate="TOO_LONG" ng-show="passwordForm.password.$error.maxlength")
-          span.help-block(translate="CANT_USE_GUID" ng-show="passwordForm.password.$error.isValid")
+          span.help-block(translate="CANT_USE_GUID" ng-show="passwordForm.password.$error.isValid && fields.password == uid")
+          span.help-block(translate="CANT_USE_EMAIL" ng-show="passwordForm.password.$error.isValid && isUserEmail(fields.password)")
     .form-group(ng-class="{'has-error': passwordForm.confirmation.$invalid && passwordForm.confirmation.$touched, 'has-success': passwordForm.confirmation.$valid}")
       label.col-sm-4.control-label(translate="CONFIRM_PASSWORD")
       .col-sm-8
-        input.form-control(on-enter="changePassword()" type="password" name="confirmation" ng-model="fields.confirmation" is-valid="fields.confirmation == fields.password" required)
+        input.form-control(
+          on-enter="changePassword()"
+          type="password"
+          name="confirmation"
+          ng-model="fields.confirmation"
+          is-valid="fields.confirmation == fields.password"
+          required)
         span.help-block(translate="NO_MATCH" ng-show="passwordForm.confirmation.$error.isValid && passwordForm.confirmation.$touched")
 .modal-footer.pal.flex-end
   .form-group.col-sm-8.has-error(ng-show="errors.unsuccessful")

--- a/app/partials/settings/preferences.jade
+++ b/app/partials/settings/preferences.jade
@@ -77,4 +77,4 @@ form.form-horizontal(role="form",name="form",novalidate)
       label.type-h5.em-400(translate="AUTO_LOGOUT")
       p.em-300.text.line-height.hidden-sm.hidden-xs(translate="AUTO_LOGOUT_EXPLAIN") 
     .col-sm-12.col-md-6.setting-result
-      bc-async-input(ng-model="settings.logoutTimeMinutes" validator="validateLogoutTime" is-required on-save="changeLogoutTime" action-title="'CHANGE' | translate")
+      bc-async-input(ng-model="settings.logoutTimeMinutes" validator="validateLogoutTime" is-required on-save="changeLogoutTime" action-title="'CHANGE' | translate" unit="minutes")

--- a/app/templates/activity-feed.jade
+++ b/app/templates/activity-feed.jade
@@ -13,7 +13,8 @@
           p.af-date.mlm.flex-1.hidden-xs.mvn {{::activity.time | date:'mediumDate'}}
           .af-log.flex-center.flex-3.flex-end
             p.mvn(ng-class="activity.message.toLowerCase()" translate="{{::activity.message}}")
-            span.pls(ng-show="activity.type == 0") {{::activity.result | convert}}
+            span.pls(ng-show="activity.type == 0")
+              fiat-or-btc(btc="activity.result")
       //psuedo empty-state
       li.af-item.flex-align-start(ng-hide="loading || activities.length > 7")
         .af-marker

--- a/app/templates/bc-async-input.jade
+++ b/app/templates/bc-async-input.jade
@@ -1,6 +1,7 @@
 div
   div(ng-hide="status.edit || inline")
     h2.status.complete.hidden-xs.long-input(ng-if="!transform") {{ ngModel }}
+      span(ng-if="unit") &nbsp;{{ unit }}
     h2.status.complete.hidden-xs.long-input(ng-if="transform") {{ ngModel | toBitCurrency:transform }}
     button.button-primary(ng-click="edit()") {{ actionTitle }}
   form(role="form" name="bcAsyncForm" ng-submit="save()" novalidate)

--- a/assets/js/controllers/send.controller.js
+++ b/assets/js/controllers/send.controller.js
@@ -161,12 +161,17 @@ function SendCtrl($scope, $log, Wallet, Alerts, currency, $uibModalInstance, $ti
 
     Alerts.clear($scope.alerts);
 
-    if ($scope.transaction.publicNote) {
-      $scope.payment.note($scope.transaction.note);
-    }
+    var note = $scope.transaction.publicNote ? $scope.transaction.note : null;
+    $scope.payment.note(note);
+
+    let paymentCheckpoint;
+    const setCheckpoint = (payment) => {
+      paymentCheckpoint = payment;
+    };
 
     const transactionFailed = (message) => {
       $scope.sending = false;
+      $scope.payment = new Wallet.payment(paymentCheckpoint).build();
       if (message) {
         $translate(message).then(t => {
           Alerts.displayError(t, false, $scope.alerts);
@@ -204,7 +209,8 @@ function SendCtrl($scope, $log, Wallet, Alerts, currency, $uibModalInstance, $ti
     };
 
     const signAndPublish = (passphrase) => {
-      return $scope.payment.sign(passphrase).publish().payment;
+      return $scope.payment.sideEffect(setCheckpoint)
+        .sign(passphrase).publish().payment;
     };
 
     Wallet.askForSecondPasswordIfNeeded().then(signAndPublish)

--- a/assets/js/controllers/settings/changePassword.controller.js
+++ b/assets/js/controllers/settings/changePassword.controller.js
@@ -14,6 +14,12 @@ function ChangePasswordCtrl($scope, $log, Wallet, Alerts, $uibModalInstance, $tr
   $scope.errors = {};
   $scope.status = {};
 
+  $scope.isUserEmail = (candidate) => {
+    return ('string' === typeof candidate &&
+            candidate.length &&
+            candidate === Wallet.user.email);
+  };
+
   $scope.changePassword = () => {
     if (!$scope.passwordForm.$valid) return;
 

--- a/assets/js/directives/bc-async-input.directive.js
+++ b/assets/js/directives/bc-async-input.directive.js
@@ -17,6 +17,7 @@ function bcAsyncInput($timeout, Wallet) {
       onChange: '=',
       actionTitle: '=',
       placeholder: '=',
+      unit: '@',
       _type: '@type',
       errorMessage: '=',
       _buttonClass: '@buttonClass',

--- a/locales/en-human.json
+++ b/locales/en-human.json
@@ -97,6 +97,7 @@
   "TOO_SHORT" : "Too short",
   "NO_MATCH" : "Does not match",
   "CANT_USE_GUID" : "You cannot use a guid as your password",
+  "CANT_USE_EMAIL" : "You cannot use your email as your password",
   "ADD_PASSWORD_HINT" : "Create Password Hint",
   "PASSWORD_HINT" : "Password Hint",
   "PASSWORD_HINT_EXPLAIN" : "Your Blockchain Wallet never communicates your password to our servers. This means we have no idea what your password is and we cannot reset it if you forget it. Create a memorable password hint that we can send to your verified email address in case you forget your password.",


### PR DESCRIPTION
Several medium-priority issues fixed:
  * User can no longer set main password to their email address
  * If sending fails, allow pressing "send" again to retry (especially useful if send failed due to inability to set public note)
  * Currency values in activity feed now get converted to whatever the display currency is, rather than only btc
  * Allow addition of a "unit" to bc-async-input directives, so that settings can have a unit (for example: logout time, which now has a "minutes" unit)