### PR TITLE
fix(send): pass payment through error

### DIFF
--- a/assets/js/controllers/send.controller.js
+++ b/assets/js/controllers/send.controller.js
@@ -386,6 +386,7 @@ function SendCtrl($scope, $log, Wallet, Alerts, currency, $uibModalInstance, $ti
         $scope.backToForm();
         Alerts.displayError(msg, false, $scope.alerts);
         $scope.$root.$safeApply($scope);
+        return response.payment;
       });
   };
 


### PR DESCRIPTION
Before, the internal promise of the payment object would end when buildbeta failed. Returning the payment object from the catch callback allows continuing the payment process.