### PR TITLE
Format service and ui-select upgrade

### DIFF
--- a/app/index.jade
+++ b/app/index.jade
@@ -159,6 +159,7 @@ head
   script(src='build/js/services/alerts.service.js')
   script(src='build/js/services/languages.service.js')
   script(src='build/js/services/currency.service.js')
+  script(src='build/js/services/format.service.js')
   
   script(src='build/js/templates.js')
       

--- a/assets/js/controllers/request.controller.js
+++ b/assets/js/controllers/request.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller("RequestCtrl", RequestCtrl);
 
-function RequestCtrl($scope, Wallet, Alerts, currency, $uibModalInstance, $log, destination, focus, $translate, $stateParams, filterFilter, $filter) {
+function RequestCtrl($scope, Wallet, Alerts, currency, $uibModalInstance, $log, destination, focus, $translate, $stateParams, filterFilter, $filter, format) {
   $scope.status = Wallet.status;
   $scope.settings = Wallet.settings;
   $scope.accounts = Wallet.accounts;
@@ -19,23 +19,21 @@ function RequestCtrl($scope, Wallet, Alerts, currency, $uibModalInstance, $log, 
     label: ""
   };
 
-  for(const account of $scope.accounts()) {
+  for(let account of $scope.accounts()) {
     if (account.index != null && !account.archived) {
-      let acct = angular.copy(account);
-      acct.type = "";
-      $scope.destinations.push(acct);
+      account = format.destination(account);
+      $scope.destinations.push(angular.copy(account));
       if ((destination != null) && (destination.index != null) && destination.index === acct.index) {
         $scope.fields.to = acct;
       }
     }
   };
 
-  for (const address of $scope.legacyAddresses()) {
+  for (let address of $scope.legacyAddresses()) {
+    address = format.destination(address);
+
     if (!address.archived) {
-      const addr = angular.copy(address);
-      addr.type = "Imported Addresses";
-      addr.label = addr.label || addr.address;
-      $scope.destinations.push(addr);
+      $scope.destinations.push(angular.copy(address));
       if ((destination != null) && (destination.address != null) && destination.address === addr.address) {
         $scope.fields.to = addr;
       }

--- a/assets/js/controllers/send.controller.js
+++ b/assets/js/controllers/send.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller("SendCtrl", SendCtrl);
 
-function SendCtrl($scope, $log, Wallet, Alerts, currency, $uibModalInstance, $timeout, $state, $filter, $stateParams, $translate, paymentRequest, filterFilter, $uibModal) {
+function SendCtrl($scope, $log, Wallet, Alerts, currency, $uibModalInstance, $timeout, $state, $filter, $stateParams, $translate, paymentRequest, filterFilter, $uibModal, format) {
 
   $scope.legacyAddresses = Wallet.legacyAddresses;
   $scope.accounts = Wallet.accounts;
@@ -264,19 +264,6 @@ function SendCtrl($scope, $log, Wallet, Alerts, currency, $uibModalInstance, $ti
     });
   };
 
-  $scope.formatOrigin = (origin) => {
-    const formatted = {
-      label: origin.label || origin.address,
-      index: origin.index,
-      address: origin.address,
-      balance: origin.balance,
-      archived: origin.archived
-    };
-    formatted.type = origin.index != null ? '' : 'Imported Addresses';
-    if (origin.index == null) formatted.isWatchOnly = origin.isWatchOnly;
-    return formatted;
-  };
-
   $scope.hasAmountError = (index) => {
     let field = $scope.sendForm['amounts' + index];
     let fieldFiat = $scope.sendForm['amountsFiat' + index];
@@ -319,7 +306,7 @@ function SendCtrl($scope, $log, Wallet, Alerts, currency, $uibModalInstance, $ti
         let selectedIdx = parseInt($stateParams.accountIndex);
         let idx = isNaN(selectedIdx) ? defaultIdx : selectedIdx;
         for (let account of $scope.accounts()) {
-          account = $scope.formatOrigin(account);
+          account = format.origin(account);
           if (account.index != null && !account.archived) {
             if (account.index === idx) {
               $scope.transaction.from = account;
@@ -329,7 +316,7 @@ function SendCtrl($scope, $log, Wallet, Alerts, currency, $uibModalInstance, $ti
           }
         }
         for (let address of $scope.legacyAddresses()) {
-          address = $scope.formatOrigin(address);
+          address = format.origin(address);
           if (!address.archived) {
             $scope.destinationsBase.push(address);
             if (!address.isWatchOnly) {
@@ -347,7 +334,7 @@ function SendCtrl($scope, $log, Wallet, Alerts, currency, $uibModalInstance, $ti
         if ((paymentRequest.address != null) && paymentRequest.address !== '') {
           $scope.applyPaymentRequest(paymentRequest, 0);
         } else if (paymentRequest.toAccount != null) {
-          $scope.transaction.destinations[0] = $scope.formatOrigin(paymentRequest.toAccount);
+          $scope.transaction.destinations[0] = format.origin(paymentRequest.toAccount);
           $scope.transaction.from = paymentRequest.fromAddress;
         } else if (paymentRequest.fromAccount != null) {
           $scope.transaction.from = paymentRequest.fromAccount;

--- a/assets/js/services/format.service.js
+++ b/assets/js/services/format.service.js
@@ -1,0 +1,32 @@
+
+angular
+  .module('walletApp')
+  .factory('format', format);
+
+format.$inject = [];
+
+function format() {
+
+  const service = {
+    origin: originDestination,
+    destination: originDestination
+  }
+
+  return service;
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  function originDestination(o) {
+    const formatted = {
+      label: o.label || o.address,
+      index: o.index,
+      address: o.address,
+      balance: o.balance,
+      archived: o.archived
+    };
+    formatted.type = o.index != null ? '' : 'Imported Addresses';
+    if (o.index == null) formatted.isWatchOnly = o.isWatchOnly;
+    return formatted;
+  }
+
+}

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "angular-bootstrap": "0.14.*",
     "angular-cookies": "1.4.*",
     "angular-audio": "1.6.*",
-    "angular-ui-select": "sjors/ui-select#csp-and-reset-search",
+    "angular-ui-select": "0.14.*",
     "angular-sanitize": "1.4.*",
     "angular-qr": "0.2.*",
     "angular-translate": "2.7.*",

--- a/dependency-whitelist.json
+++ b/dependency-whitelist.json
@@ -2,7 +2,7 @@
   "ignore" : [
     "angular", "angular-mocks", "angular-animate", "angular-bootstrap", "angular-cookies", "angular-sanitize",
     "bootstrap-sass",
-    "angular-ui-select", "bc-phone-number"
+    "bc-phone-number"
   ],
   "pgp-signed" : [
     "blockchain-wallet",
@@ -23,8 +23,8 @@
     "repo" : "danielstern/ngAudio"
   },
   "angular-ui-select" : {
-    "version": "0.12.0",
-    "commits" : ["2d1422d109dc1cd64213271e59506b14f74d356f"],
+    "version": "0.14.2",
+    "commits" : ["85401e081c4e048b7a32bde0ee513ab1dbdecf9b"],
     "repo" : "angular-ui/ui-select"
   },
   "angular-qr" : {

--- a/tests/services/currency.service.spec.js
+++ b/tests/services/currency.service.spec.js
@@ -153,14 +153,21 @@ describe('currency', () => {
 
   describe('formatCurrencyForView()', () => {
     let amount = 0.123456789;
-    let viewValues = ['0.12345679 BTC', '0.12346 mBTC', '0.12 bits'];
 
-    for (let i in viewValues) {
-      it(`should format btc currency ${i}`, inject((Wallet, currency) => {
-        let formatted = currency.formatCurrencyForView(amount, currency.bitCurrencies[i]);
-        expect(formatted).toEqual(viewValues[i]);
-      }));
-    }
+    it('should format BTC', inject((Wallet, currency) => {
+      let formatted = currency.formatCurrencyForView(amount, currency.bitCurrencies[0]);
+      expect(formatted).toEqual('0.12345679 BTC');
+    }));
+
+    it('should format mBTC', inject((Wallet, currency) => {
+      let formatted = currency.formatCurrencyForView(amount, currency.bitCurrencies[1]);
+      expect(formatted).toEqual('0.12346 mBTC');
+    }));
+
+    it('should format bits', inject((Wallet, currency) => {
+      let formatted = currency.formatCurrencyForView(amount, currency.bitCurrencies[2]);
+      expect(formatted).toEqual('0.12 bits');
+    }));
 
     it('should not format a null amount', inject((Wallet, currency) => {
       let formatted = currency.formatCurrencyForView(null, currency.currencies[0]);

--- a/tests/services/format.service.spec.js
+++ b/tests/services/format.service.spec.js
@@ -1,0 +1,53 @@
+'use strict';
+
+describe('format', () => {
+
+  beforeEach(angular.mock.module('walletApp'));
+
+  describe("origin()", () => {
+    it('should format an account', inject((format) => {
+      expect(format.origin({
+        label : "Savings",
+        index : 0,
+        balance : 1,
+        archived : false,
+        isWatchOnly : false
+      })).toEqual({
+        label : "Savings",
+        index : 0,
+        address : undefined,
+        balance : 1,
+        archived : false,
+        type : ''
+      });
+    }));
+
+    it('should format an address', inject((format) => {
+      expect(format.origin({
+        label : "Imported",
+        index: undefined,
+        address: "1234ab",
+        balance : 1,
+        archived : false,
+        isWatchOnly : false
+      })).toEqual({
+        label : "Imported",
+        index: undefined,
+        address : "1234ab",
+        balance : 1,
+        archived : false,
+        type : 'Imported Addresses',
+        isWatchOnly : false
+      });
+    }));
+  });
+
+  describe("destination()", () => {
+    it('should be the same as origin', inject((format) => {
+      expect(format.origin).toEqual(format.destination);
+    }));
+  });
+
+
+
+});


### PR DESCRIPTION
Don't forget to `bower update`. 

We were using a custom fork of ui-select pending a PR I made with them a while ago. This has been merged and a new version has been released, so using that. 

Unfortunately the receive modal started to freeze up. I reused the format origin code from the send screen, put it into a separate service and added some tests.

I don't know why one currency service test suddenly started breaking.