### PR TITLE
Move QR scanner to popover window

### DIFF
--- a/app/index.jade
+++ b/app/index.jade
@@ -150,6 +150,7 @@ head
   script(src='build/js/directives/scroll-in-view.directive.js')
   script(src='build/js/directives/public-header.directive.js')
   script(src='build/js/directives/async-select.directive.js')
+  script(src='build/js/directives/qr-scan.directive.js')
   
   script(src='build/js/services/wallet.service.js')
   script(src='build/js/services/securityCenter.service.js')

--- a/app/partials/send.jade
+++ b/app/partials/send.jade
@@ -51,7 +51,8 @@
                 name="{{ 'destinations' + $index }}"
                 ng-model="transaction.destinations[$index]"
                 ng-model-options="{ updateOn: 'blur' }"
-                ng-change="updateToLabel(); checkForSameDestination(); setQRIndex($index)")
+                ng-change="updateToLabel(); checkForSameDestination();"
+                on-payment-request="applyPaymentRequest(request, $index)")
             .has-error
               span.help-block(translate="BITCOIN_ADDRESS_INVALID" ng-show="sendForm['destinations' + $index].$error.isValidAddress && sendForm['destinations' + $index].$touched && transaction.destinations[$index].address !== ''")
               span.help-block(translate="SAME_DESTINATION" ng-show="sendForm['destinations' + $index].$error.isNotEqual")

--- a/app/partials/send.jade
+++ b/app/partials/send.jade
@@ -51,8 +51,7 @@
                 name="{{ 'destinations' + $index }}"
                 ng-model="transaction.destinations[$index]"
                 ng-model-options="{ updateOn: 'blur' }"
-                ng-change="updateToLabel(); checkForSameDestination(); refreshTxProposal()"
-                on-request-qr="cameraOn($index)")
+                ng-change="updateToLabel(); checkForSameDestination(); refreshTxProposal()")
             .has-error
               span.help-block(translate="BITCOIN_ADDRESS_INVALID" ng-show="sendForm['destinations' + $index].$error.isValidAddress && sendForm['destinations' + $index].$touched && transaction.destinations[$index].address !== ''")
               span.help-block(translate="SAME_DESTINATION" ng-show="sendForm['destinations' + $index].$error.isNotEqual")
@@ -128,11 +127,6 @@
                          when="{'1': '{{block | translate}}', 'other': '{{blocks | translate}}' }")
             span ).
           span.has-error(ng-show="blockIdx > 6" translate="SMALL_FEE_WARNING")
-      //- QR Scanner 
-      .form-group.row(ng-hide="!cameraIsOn")
-        label.col-sm-2.col-xs-12(translate="QR")
-        .col-sm-10.col-xs-12
-          bc-qr-reader(active="cameraRequested", on-result="processURLfromQR" on-error="onError" camera-status="cameraIsOn")
   //- Step 2 (confirmation)
   div.overview(ng-show="confirmationStep")
     .flex-column
@@ -188,9 +182,6 @@
     a.dark-grey(ng-hide="advanced || confirmationStep", ng-click="advancedSend()", translate="ADVANCED_SEND")
     a.dark-grey(ng-show="advanced && !confirmationStep", ng-click="regularSend()", translate="REGULAR_SEND")
   .flex-center.flex-end.send-actions
-    button.button-muted-off.mrm(
-      ng-click="cameraOff()" ng-show="cameraIsOn" translate="CAMERA_OFF")
-
     button.button-muted.mrm(
       ng-click="close()" translate="CANCEL" ng-hide="confirmationStep")
 

--- a/app/partials/send.jade
+++ b/app/partials/send.jade
@@ -51,7 +51,7 @@
                 name="{{ 'destinations' + $index }}"
                 ng-model="transaction.destinations[$index]"
                 ng-model-options="{ updateOn: 'blur' }"
-                ng-change="updateToLabel(); checkForSameDestination(); refreshTxProposal()")
+                ng-change="updateToLabel(); checkForSameDestination(); setQRIndex($index)")
             .has-error
               span.help-block(translate="BITCOIN_ADDRESS_INVALID" ng-show="sendForm['destinations' + $index].$error.isValidAddress && sendForm['destinations' + $index].$touched && transaction.destinations[$index].address !== ''")
               span.help-block(translate="SAME_DESTINATION" ng-show="sendForm['destinations' + $index].$error.isNotEqual")

--- a/app/partials/settings/import-address.jade
+++ b/app/partials/settings/import-address.jade
@@ -88,7 +88,7 @@
 .modal-footer.pal.flex-end
   button.button-muted.mrm(ng-click="close()", translate="CANCEL", ng-show="(step == 1 || step == 3) && !status.busy")
   span(ng-if="step == 1")
-    button.btn.btn-info(ng-click="cameraOn()" ng-disabled="status.busy" ng-if="browserWithCamera" translate="QR")
+    qr-scan(on-scan="onAddressScan")
     button.btn.btn-primary(ui-ladda="status.busy" ng-click="import()" ng-disabled="importForm.$invalid" ladda-translate="IMPORT" data-style="expand-left")
   button.btn.btn-info(ng-show="step == 2", ng-click="close()", translate="CLOSE")
   button.btn.btn-primary(ng-show="step == 2 && !address.isWatchOnly && address.balance > 0" ng-click="goToTransfer()" translate="SWEEP")

--- a/app/templates/destination-input.jade
+++ b/app/templates/destination-input.jade
@@ -16,12 +16,9 @@
       ng-blur="blur()"
     )
     .input-group-btn(uib-dropdown)
-      button#qr.btn.btn-default(
-        type="button"
-        ng-disabled="!browserWithCamera"
-        ng-class="{ 'border-rounded-right': accounts.length <= 1 }"
-        ng-click="onRequestQr()")
-        img(src="img/qr-code.png" alt="QR")
+      qr-scan(
+        on-scan="onAddressScan"
+        ng-class="{ 'border-rounded-right': accounts.length <= 1 }")
       button.btn.btn-default(
         type="button"
         ng-show="accounts.length > 1"

--- a/app/templates/qr-scan-button.jade
+++ b/app/templates/qr-scan-button.jade
@@ -2,9 +2,10 @@ button.qr-scan-button.btn.btn-default(
   type="button"
   ng-disabled="!browserWithCamera"
   uib-popover-template="popoverTemplate"
-  uib-popover-placement="top"
   popover-trigger="outsideClick"
   popover-is-open="cameraOn"
   popover-append-to-body="true"
+  popover-class="qr-popover"
   ng-click="cameraOn = true")
   img(src="img/qr-code.png" alt="QR")
+

--- a/app/templates/qr-scan-button.jade
+++ b/app/templates/qr-scan-button.jade
@@ -5,5 +5,6 @@ button.qr-scan-button.btn.btn-default(
   uib-popover-placement="top"
   popover-trigger="outsideClick"
   popover-is-open="cameraOn"
+  popover-append-to-body="true"
   ng-click="cameraOn = true")
   img(src="img/qr-code.png" alt="QR")

--- a/app/templates/qr-scan-button.jade
+++ b/app/templates/qr-scan-button.jade
@@ -1,0 +1,9 @@
+button.qr-scan-button.btn.btn-default(
+  type="button"
+  ng-disabled="!browserWithCamera"
+  uib-popover-template="popoverTemplate"
+  uib-popover-placement="top"
+  popover-trigger="outsideClick"
+  popover-is-open="cameraOn"
+  ng-click="cameraOn = true")
+  img(src="img/qr-code.png" alt="QR")

--- a/app/templates/qr-scan-popover.jade
+++ b/app/templates/qr-scan-popover.jade
@@ -1,0 +1,14 @@
+.qr-scan-popover
+  bc-qr-reader(
+    ng-hide="scanComplete"
+    on-result="onCameraResult"
+    on-error="onCameraError"
+    active="cameraOn"
+    camera-status="cameraOn")
+  .qr-result(ng-show="scanComplete")
+    .flex-center.flex-justify.flex-column(ng-show="scanSuccess")
+      i.ti-check.bright-green
+      span.bright-green(translate="SCAN_SUCCESS")
+    .flex-center.flex-justify.flex-column(ng-hide="scanSuccess")
+      i.ti-close.security-red
+      span.security-red(translate="SCAN_FAILED")

--- a/app/templates/qr-scan-popover.jade
+++ b/app/templates/qr-scan-popover.jade
@@ -5,10 +5,10 @@
     on-error="onCameraError"
     active="cameraOn"
     camera-status="cameraOn")
-  .qr-result(ng-show="scanComplete")
-    .flex-center.flex-justify.flex-column(ng-show="scanSuccess")
+  .qr-result.flex-justify.flex-center(ng-show="scanComplete")
+    .flex-center.flex-column(ng-show="scanSuccess")
       i.ti-check.bright-green
       span.bright-green(translate="SCAN_SUCCESS")
-    .flex-center.flex-justify.flex-column(ng-hide="scanSuccess")
+    .flex-center.flex-column(ng-hide="scanSuccess")
       i.ti-close.security-red
       span.security-red(translate="SCAN_FAILED")

--- a/assets/css/blockchain.css.scss
+++ b/assets/css/blockchain.css.scss
@@ -31,6 +31,7 @@
 @import 'components/spinner';
 @import 'components/virtual-keyboard';
 @import 'components/feedback';
+@import 'components/qr-scan';
 
 //import modules
 @import 'modules/destination-input';

--- a/assets/css/components/_modals.scss
+++ b/assets/css/components/_modals.scss
@@ -121,7 +121,8 @@
   @include clearfix; // clear it in case folks use .pull-* classes on buttons
 
   // Properly space out buttons
-  .btn + .btn {
+  .btn + .btn,
+  .popover + .btn {
     margin-left: 5px;
     margin-bottom: 0; // account for input[type="submit"] which gets the bottom margin like all other inputs
   }

--- a/assets/css/components/_qr-scan.scss
+++ b/assets/css/components/_qr-scan.scss
@@ -1,0 +1,19 @@
+
+.qr-scan-button {
+  img {
+    height: 18px;
+    width: 18px;
+  }
+}
+
+.qr-scan-popover {
+  height: 150px;
+  .qr-result {
+    padding-top: 40px;
+    i { font-size: 2.5em; }
+  }
+  video {
+    width: 100%;
+    height: 100%;
+  }
+}

--- a/assets/css/components/_qr-scan.scss
+++ b/assets/css/components/_qr-scan.scss
@@ -6,14 +6,36 @@
   }
 }
 
-.qr-scan-popover {
-  height: 150px;
-  .qr-result {
-    padding-top: 40px;
-    i { font-size: 2.5em; }
+.qr-popover {
+  border-radius: 0px !important;
+  border: 0px;
+  .popover-content {
+    padding: 0px;
+    &:before {
+      top: 50%;
+      left: 50%;
+      content: '';
+      width: 140px;
+      height: 140px;
+      display: block;
+      position: absolute;
+      border: 2px dashed $grey;
+      transform: translate(-50%, -50%);
+    }
   }
-  video {
-    width: 100%;
-    height: 100%;
+  .qr-scan-popover {
+    height: 164px;
+    overflow: hidden;
+    .qr-result {
+      width: 100%;
+      height: 100%;
+      background: white;
+      position: absolute;
+      i { font-size: 2.5em; }
+    }
+    video {
+      width: 100%;
+      height: 100%;
+    }
   }
 }

--- a/assets/css/modules/_destination-input.scss
+++ b/assets/css/modules/_destination-input.scss
@@ -1,10 +1,4 @@
 .destination-input {
-  #qr {
-    img {
-      height: 18px;
-      width: 18px;
-    }
-  }
   .form-control {
     width: 100%;
     border: 1px solid $grey;

--- a/assets/css/modules/_send-receive.scss
+++ b/assets/css/modules/_send-receive.scss
@@ -117,3 +117,7 @@
     clear: left;
   }
 }
+
+.popover {
+  z-index: 1060;
+}

--- a/assets/js/controllers/send.controller.js
+++ b/assets/js/controllers/send.controller.js
@@ -104,17 +104,13 @@ function SendCtrl($scope, $log, Wallet, Alerts, currency, $uibModalInstance, $ti
     });
   };
 
-  $scope.processURLfromQR = (url) => {
-    paymentRequest = Wallet.parsePaymentRequest(url);
-    if (paymentRequest.isValid) {
-      $scope.applyPaymentRequest(paymentRequest, $scope.qrIndex);
-    } else {
-      $translate("QR_CODE_NOT_BITCOIN").then(translation => {
-        Alerts.displayWarning(translation, false, $scope.alerts);
-      });
-      $log.error("Not a bitcoin QR code:" + url);
-    }
+  $scope.processURLfromQR = (e, result) => {
+    paymentRequest = Wallet.parsePaymentRequest(result.url);
+    $scope.applyPaymentRequest(paymentRequest, $scope.qrIndex);
   };
+
+  $scope.setQRIndex = (i) => { $scope.qrIndex = i; }
+  $rootScope.$on('qr-scan-success', $scope.processURLfromQR);
 
   $scope.close = () => {
     Alerts.clear($scope.alerts);

--- a/assets/js/controllers/send.controller.js
+++ b/assets/js/controllers/send.controller.js
@@ -17,7 +17,6 @@ function SendCtrl($scope, $log, Wallet, Alerts, currency, $uibModalInstance, $ti
   $scope.destinationsBase = [];
   $scope.originsLoaded = false;
 
-  $scope.cameraIsOn = false;
   $scope.sending = false;
   $scope.amountIsValid = true;
   $scope.confirmationStep = false;
@@ -109,25 +108,12 @@ function SendCtrl($scope, $log, Wallet, Alerts, currency, $uibModalInstance, $ti
     paymentRequest = Wallet.parsePaymentRequest(url);
     if (paymentRequest.isValid) {
       $scope.applyPaymentRequest(paymentRequest, $scope.qrIndex);
-      $scope.cameraOff();
     } else {
       $translate("QR_CODE_NOT_BITCOIN").then(translation => {
         Alerts.displayWarning(translation, false, $scope.alerts);
       });
       $log.error("Not a bitcoin QR code:" + url);
     }
-  };
-
-  $scope.cameraOn = (index=0) => {
-    $scope.cameraRequested = true;
-    $scope.qrIndex = index;
-  };
-
-  $scope.cameraOff = () => {
-    $scope.cameraIsOn = false;
-    $scope.cameraRequested = false;
-    $scope.qrIndex = null;
-    $scope.$broadcast("STOP_WEBCAM");
   };
 
   $scope.close = () => {

--- a/assets/js/controllers/send.controller.js
+++ b/assets/js/controllers/send.controller.js
@@ -86,7 +86,6 @@ function SendCtrl($scope, $log, Wallet, Alerts, currency, $uibModalInstance, $ti
   };
 
   $scope.applyPaymentRequest = (paymentRequest, i) => {
-    $scope.processingPaymentRequest = true;
     let destination = {
       address: paymentRequest.address || "",
       label: paymentRequest.address || "",
@@ -97,20 +96,7 @@ function SendCtrl($scope, $log, Wallet, Alerts, currency, $uibModalInstance, $ti
     $scope.transaction.note = paymentRequest.message || '';
     $scope.validateAmounts();
     $scope.updateToLabel();
-    $scope.$$postDigest(() => {
-      $timeout(() => {
-        $scope.processingPaymentRequest = false;
-      }, 3000);
-    });
   };
-
-  $scope.processURLfromQR = (e, result) => {
-    paymentRequest = Wallet.parsePaymentRequest(result.url);
-    $scope.applyPaymentRequest(paymentRequest, $scope.qrIndex);
-  };
-
-  $scope.setQRIndex = (i) => { $scope.qrIndex = i; }
-  $rootScope.$on('qr-scan-success', $scope.processURLfromQR);
 
   $scope.close = () => {
     Alerts.clear($scope.alerts);

--- a/assets/js/controllers/settings/addressImport.controller.js
+++ b/assets/js/controllers/settings/addressImport.controller.js
@@ -151,7 +151,7 @@ function AddressImportCtrl($scope, $log, Wallet, Alerts, $uibModalInstance, $tra
     $scope.$broadcast("STOP_WEBCAM");
   };
 
-  $scope.processURLfromQR = (url) => {
+  $scope.onAddressScan = (url) => {
     $scope.fields.addressOrPrivateKey = $scope.parseBitcoinUrl(url);
     $scope.cameraOff();
     let valid = $scope.isValidAddressOrPrivateKey($scope.fields.addressOrPrivateKey);

--- a/assets/js/directives/destinationInput.directive.js
+++ b/assets/js/directives/destinationInput.directive.js
@@ -10,7 +10,6 @@ function destinationInput($rootScope, $timeout, Wallet) {
     require: 'ngModel',
     scope: {
       model: '=ngModel',
-      onRequestQr: '&',
       change: '&ngChange'
     },
     templateUrl: 'templates/destination-input.jade',
@@ -23,22 +22,27 @@ function destinationInput($rootScope, $timeout, Wallet) {
     scope.accounts = Wallet.accounts().filter(a => a.active);
 
     let format = (a, type) => ({
-      label     : a.label,
+      label     : a.label || a.address || '',
+      address   : a.address || '',
+      index     : a.index,
       balance   : a.balance,
       active    : a.active,
       archived  : a.archived,
       type      : type
     });
 
+    scope.onAddressScan = (address) => {
+      scope.model = format(address, 'External');
+      $timeout(scope.change);
+    };
+
     scope.setModel = (a) => {
       scope.model = format(a, 'Accounts');
-      scope.model.index = a.index;
       $timeout(scope.change);
     };
 
     scope.clearModel = () => {
       scope.model = format({}, 'External');
-      scope.model.address = '';
       $timeout(scope.change);
     };
 

--- a/assets/js/directives/destinationInput.directive.js
+++ b/assets/js/directives/destinationInput.directive.js
@@ -31,7 +31,8 @@ function destinationInput($rootScope, $timeout, Wallet) {
       type      : type
     });
 
-    scope.onAddressScan = (address) => {
+    scope.onAddressScan = (result) => {
+      let address = Wallet.parsePaymentRequest(result)
       scope.model = format(address, 'External');
       $timeout(scope.change);
     };

--- a/assets/js/directives/destinationInput.directive.js
+++ b/assets/js/directives/destinationInput.directive.js
@@ -10,7 +10,8 @@ function destinationInput($rootScope, $timeout, Wallet) {
     require: 'ngModel',
     scope: {
       model: '=ngModel',
-      change: '&ngChange'
+      change: '&ngChange',
+      onPaymentRequest: '&onPaymentRequest'
     },
     templateUrl: 'templates/destination-input.jade',
     link: link
@@ -34,6 +35,8 @@ function destinationInput($rootScope, $timeout, Wallet) {
     scope.onAddressScan = (result) => {
       let address = Wallet.parsePaymentRequest(result)
       scope.model = format(address, 'External');
+
+      $timeout(scope.onPaymentRequest({request: address}))
       $timeout(scope.change);
     };
 

--- a/assets/js/directives/destinationInput.directive.js
+++ b/assets/js/directives/destinationInput.directive.js
@@ -35,8 +35,7 @@ function destinationInput($rootScope, $timeout, Wallet) {
     scope.onAddressScan = (result) => {
       let address = Wallet.parsePaymentRequest(result)
       scope.model = format(address, 'External');
-
-      $timeout(scope.onPaymentRequest({request: address}))
+      scope.onPaymentRequest({request: address});
       $timeout(scope.change);
     };
 

--- a/assets/js/directives/qr-scan.directive.js
+++ b/assets/js/directives/qr-scan.directive.js
@@ -21,10 +21,12 @@ function qrScan($rootScope, $timeout, $translate, Wallet, Alerts) {
 
     scope.onCameraResult = (result) => {
       scope.scanComplete = true;
-      let paymentRequest = Wallet.parsePaymentRequest(result);
 
-      scope.scanSuccess = paymentRequest.isValid;
-      if (scope.scanSuccess && scope.onScan) scope.onScan(paymentRequest);
+      scope.scanSuccess = Wallet.isValidAddress(Wallet.parsePaymentRequest(result).address) ||
+                          Wallet.isValidPrivateKey(result) ||
+                          Wallet.isValidAddress(result)
+
+      if (scope.scanSuccess && scope.onScan) scope.onScan(result);
 
       $timeout(() => scope.cameraOn = false, 1250);
       $timeout(() => scope.scanComplete = false, 1500);

--- a/assets/js/directives/qr-scan.directive.js
+++ b/assets/js/directives/qr-scan.directive.js
@@ -1,0 +1,38 @@
+
+angular
+  .module('walletApp')
+  .directive('qrScan', qrScan);
+
+function qrScan($rootScope, $timeout, $translate, Wallet, Alerts) {
+  const directive = {
+    restrict: 'E',
+    replace: true,
+    scope: {
+      onScan: '='
+    },
+    templateUrl: 'templates/qr-scan-button.jade',
+    link: link
+  };
+  return directive;
+
+  function link(scope) {
+    scope.popoverTemplate = 'templates/qr-scan-popover.jade';
+    scope.browserWithCamera = $rootScope.browserWithCamera;
+
+    scope.onCameraResult = (result) => {
+      scope.scanComplete = true;
+      let paymentRequest = Wallet.parsePaymentRequest(result);
+
+      scope.scanSuccess = paymentRequest.isValid;
+      if (scope.scanSuccess && scope.onScan) scope.onScan(paymentRequest);
+
+      $timeout(() => scope.cameraOn = false, 1250);
+      $timeout(() => scope.scanComplete = false, 1500);
+    };
+
+    scope.onCameraError = () => {
+      scope.cameraOn = false;
+      $translate('CAMERA_PERMISSION_DENIED').then(Alerts.displayWarning);
+    };
+  }
+}

--- a/assets/js/directives/qr-scan.directive.js
+++ b/assets/js/directives/qr-scan.directive.js
@@ -26,6 +26,9 @@ function qrScan($rootScope, $timeout, $translate, Wallet, Alerts) {
                           Wallet.isValidPrivateKey(result) ||
                           Wallet.isValidAddress(result)
 
+
+      $rootScope.$safeApply()
+
       if (scope.scanSuccess && scope.onScan) scope.onScan(result);
 
       $timeout(() => scope.cameraOn = false, 1250);

--- a/assets/js/directives/qr-scan.directive.js
+++ b/assets/js/directives/qr-scan.directive.js
@@ -28,10 +28,7 @@ function qrScan($rootScope, $timeout, $translate, Wallet, Alerts) {
 
       $rootScope.$safeApply();
 
-      if (scope.scanSuccess && scope.onScan) {
-        scope.onScan(result);
-        $timeout(() => { $rootScope.$broadcast('qr-scan-success', {url: result}) })
-      }
+      if (scope.scanSuccess && scope.onScan && scope.cameraOn) scope.onScan(result);
 
       $timeout(() => scope.cameraOn = false, 1250);
       $timeout(() => scope.scanComplete = false, 1500);

--- a/assets/js/directives/qr-scan.directive.js
+++ b/assets/js/directives/qr-scan.directive.js
@@ -26,9 +26,10 @@ function qrScan($rootScope, $timeout, $translate, Wallet, Alerts) {
                           Wallet.isValidPrivateKey(result) ||
                           Wallet.isValidAddress(result)
 
+      $rootScope.$safeApply();
+
       if (scope.scanSuccess && scope.onScan) {
         scope.onScan(result);
-        $rootScope.$safeApply();
         $rootScope.$broadcast('qr-scan-success', {url: result});
       }
 

--- a/assets/js/directives/qr-scan.directive.js
+++ b/assets/js/directives/qr-scan.directive.js
@@ -30,7 +30,7 @@ function qrScan($rootScope, $timeout, $translate, Wallet, Alerts) {
 
       if (scope.scanSuccess && scope.onScan) {
         scope.onScan(result);
-        $rootScope.$broadcast('qr-scan-success', {url: result});
+        $timeout(() => { $rootScope.$broadcast('qr-scan-success', {url: result}) })
       }
 
       $timeout(() => scope.cameraOn = false, 1250);

--- a/assets/js/directives/qr-scan.directive.js
+++ b/assets/js/directives/qr-scan.directive.js
@@ -26,10 +26,11 @@ function qrScan($rootScope, $timeout, $translate, Wallet, Alerts) {
                           Wallet.isValidPrivateKey(result) ||
                           Wallet.isValidAddress(result)
 
-
-      $rootScope.$safeApply()
-
-      if (scope.scanSuccess && scope.onScan) scope.onScan(result);
+      if (scope.scanSuccess && scope.onScan) {
+        scope.onScan(result);
+        $rootScope.$safeApply();
+        $rootScope.$broadcast('qr-scan-success', {url: result});
+      }
 
       $timeout(() => scope.cameraOn = false, 1250);
       $timeout(() => scope.scanComplete = false, 1500);

--- a/locales/en-human.json
+++ b/locales/en-human.json
@@ -60,6 +60,8 @@
   "CONFIRMED" : "Confirmed",
   "CAMERA_PERMISSION_DENIED" : "Permission to use camera denied",
   "QR_CODE_NOT_BITCOIN" : "Not a bitcoin QR code.",
+  "SCAN_SUCCESS": "Scan Successful",
+  "SCAN_FAILED": "Scan Failed",
   "WALLET_NOT_FOUND" : "Wallet not found",
   "YOU" : "You",
   "RECEIVED_BITCOIN_FROM" : "Received",

--- a/tests/controllers/send_ctrl_spec.coffee
+++ b/tests/controllers/send_ctrl_spec.coffee
@@ -142,9 +142,6 @@ describe "SendCtrl", ->
       it "should know the users btc currency", ->
         expect(scope.btcCurrency.code).toEqual('BTC')
 
-      it "should know that the camera is not on", ->
-        expect(scope.cameraIsOn).toBe(false)
-
       it "should not be sending", ->
         expect(scope.sending).toBe(false)
 
@@ -698,23 +695,6 @@ describe "SendCtrl", ->
         scope.removeDestination(0)
         expect(scope.transaction.destinations.length).toBe(1)
         expect(scope.transaction.amounts.length).toBe(1)
-
-    describe "camera", ->
-
-      it "should turn on", ->
-        spyOn(scope, '$broadcast')
-        scope.cameraOn(1)
-        expect(scope.cameraRequested).toBe(true)
-        expect(scope.qrIndex).toEqual(1)
-
-      it "should turn off", ->
-        scope.cameraIsOn = true
-        scope.cameraRequested = true
-        scope.qrIndex = 1
-        scope.cameraOff()
-        expect(scope.cameraIsOn).toBe(false)
-        expect(scope.cameraRequested).toBe(false)
-        expect(scope.qrIndex).toBeNull()
 
     describe "getFilter", ->
 

--- a/tests/controllers/send_ctrl_spec.coffee
+++ b/tests/controllers/send_ctrl_spec.coffee
@@ -554,19 +554,22 @@ describe "SendCtrl", ->
       it "should determine if balance is zero", ->
         expect(scope.hasZeroBalance({balance: 0})).toBe(true)
 
+    describe "setQRIndex", ->
+      it "should set a qrIndex", ->
+        expect(scope.qrIndex).toBeUndefined()
+        scope.setQRIndex(1)
+        expect(scope.qrIndex).toBe(1)
+
     describe "processURLfromQR", ->
 
       it "should process a succesfully scanned QR code", inject((Wallet) ->
         scope.qrIndex = 0
-        scope.processURLfromQR("bitcoin://abcdefgh?amount=0.001")
+        scope.e = 'event'
+        scope.result = {}
+        scope.result.url = 'bitcoin://abcdefgh?amount=0.001'
+        scope.processURLfromQR(scope.e, scope.result)
         expect(scope.transaction.amounts[0]).toBe(100000)
         expect(scope.transaction.destinations[0].address).toBe("abcdefgh")
-      )
-
-      it "should warn user if QR code is not recognized", inject((Wallet) ->
-        expect(scope.alerts.length).toBe(0)
-        scope.processURLfromQR("http://www.google.com")
-        expect(scope.alerts.length).toBe(1)
       )
 
     describe "updateToLabel", ->

--- a/tests/controllers/send_ctrl_spec.coffee
+++ b/tests/controllers/send_ctrl_spec.coffee
@@ -554,20 +554,11 @@ describe "SendCtrl", ->
       it "should determine if balance is zero", ->
         expect(scope.hasZeroBalance({balance: 0})).toBe(true)
 
-    describe "setQRIndex", ->
-      it "should set a qrIndex", ->
-        expect(scope.qrIndex).toBeUndefined()
-        scope.setQRIndex(1)
-        expect(scope.qrIndex).toBe(1)
+    describe "applyPaymentRequest", ->
 
-    describe "processURLfromQR", ->
-
-      it "should process a succesfully scanned QR code", inject((Wallet) ->
-        scope.qrIndex = 0
-        scope.e = 'event'
-        scope.result = {}
-        scope.result.url = 'bitcoin://abcdefgh?amount=0.001'
-        scope.processURLfromQR(scope.e, scope.result)
+      it "should succesfully apply a payment request", inject((Wallet) ->
+        scope.result = Wallet.parsePaymentRequest('bitcoin://abcdefgh?amount=0.001')
+        scope.applyPaymentRequest(scope.result, 0)
         expect(scope.transaction.amounts[0]).toBe(100000)
         expect(scope.transaction.destinations[0].address).toBe("abcdefgh")
       )

--- a/tests/directives/destination-input_spec.coffee
+++ b/tests/directives/destination-input_spec.coffee
@@ -32,3 +32,11 @@ describe "Destination Input directive", ->
     $timeout.flush()
     expect(isoScope.change).toHaveBeenCalled()
   )
+
+  it "should trigger onPaymentRequest", inject(($timeout) ->
+    spyOn(isoScope, "onPaymentRequest")
+    result = 'bitcoin:1F1tAaz5x1HUXrCNLbtMDqcw6o5GNn4xqX'
+    isoScope.onAddressScan(result)
+    $timeout.flush()
+    expect(isoScope.onPaymentRequest).toHaveBeenCalled()
+  )

--- a/tests/directives/destination-input_spec.coffee
+++ b/tests/directives/destination-input_spec.coffee
@@ -1,0 +1,34 @@
+describe "Destination Input directive", ->
+  $compile = undefined
+  $rootScope = undefined
+  element = undefined
+  isoScope = undefined
+  Wallet = undefined
+
+  beforeEach module("walletApp")
+
+  beforeEach inject((_$compile_, _$rootScope_, $injector) ->
+    $compile = _$compile_
+    $rootScope = _$rootScope_
+    scope = $rootScope.$new()
+    Wallet = $injector.get('Wallet')
+
+    Wallet.my.wallet =
+      hdwallet = () ->
+
+    return
+  )
+
+  beforeEach ->
+    element = $compile('<destination-input ng-model="transaction"></destination-input>')($rootScope)
+    $rootScope.$digest()
+    isoScope = element.isolateScope()
+    isoScope.$digest()
+
+  it "should call change on addressScan", inject(($timeout) ->
+    spyOn(isoScope, "change")
+    result = 'bitcoin:1F1tAaz5x1HUXrCNLbtMDqcw6o5GNn4xqX'
+    isoScope.onAddressScan(result)
+    $timeout.flush()
+    expect(isoScope.change).toHaveBeenCalled()
+  )

--- a/tests/directives/qr-scan_spec.coffee
+++ b/tests/directives/qr-scan_spec.coffee
@@ -31,6 +31,7 @@ describe 'qr-scan directive', ->
   )
 
   it 'should call onScan with the payment request', ->
+    isoScope.cameraOn = true
     isoScope.onCameraResult('bitcoin:1JryFnzBdE8YRu6nDzZTZtyw9Sy4RbeABL')
     expect(isoScope.onScan).toHaveBeenCalledWith('bitcoin:1JryFnzBdE8YRu6nDzZTZtyw9Sy4RbeABL')
     expect(isoScope.scanComplete).toEqual(true)

--- a/tests/directives/qr-scan_spec.coffee
+++ b/tests/directives/qr-scan_spec.coffee
@@ -3,9 +3,13 @@ describe 'qr-scan directive', ->
 
   beforeEach module('walletApp')
 
-  beforeEach inject((_$compile_, _$rootScope_) ->
+  beforeEach inject((_$compile_, _$rootScope_, $injector) ->
     $compile = _$compile_
     $rootScope = _$rootScope_
+    Wallet = $injector.get('Wallet')
+
+    Wallet.isValidAddress = () -> true
+    Wallet.isValidPrivateKey = () -> true
 
     $rootScope.onScan = jasmine.createSpy()
 
@@ -28,14 +32,13 @@ describe 'qr-scan directive', ->
 
   it 'should call onScan with the payment request', ->
     isoScope.onCameraResult('bitcoin:1JryFnzBdE8YRu6nDzZTZtyw9Sy4RbeABL')
-    expect(isoScope.onScan).toHaveBeenCalledWith(jasmine.objectContaining({
-      address: '1JryFnzBdE8YRu6nDzZTZtyw9Sy4RbeABL', isValid: true
-    }))
+    expect(isoScope.onScan).toHaveBeenCalledWith('bitcoin:1JryFnzBdE8YRu6nDzZTZtyw9Sy4RbeABL')
     expect(isoScope.scanComplete).toEqual(true)
     expect(isoScope.scanSuccess).toEqual(true)
 
   it 'should not call onScan when there is a scan error', inject((Wallet) ->
     Wallet.isValidAddress = () -> false
+    Wallet.isValidPrivateKey = () -> false
     isoScope.onCameraResult('notbitcoin:asdfasdfasdf')
     expect(isoScope.onScan).not.toHaveBeenCalled()
     expect(isoScope.scanComplete).toEqual(true)

--- a/tests/directives/qr-scan_spec.coffee
+++ b/tests/directives/qr-scan_spec.coffee
@@ -1,0 +1,50 @@
+describe 'qr-scan directive', ->
+  isoScope = undefined
+
+  beforeEach module('walletApp')
+
+  beforeEach inject((_$compile_, _$rootScope_) ->
+    $compile = _$compile_
+    $rootScope = _$rootScope_
+
+    $rootScope.onScan = jasmine.createSpy()
+
+    element = $compile('<qr-scan on-scan="onScan"></qr-scan>')($rootScope)
+    $rootScope.$digest()
+    isoScope = element.isolateScope()
+    isoScope.$digest()
+  )
+
+  it 'should have a template url', ->
+    expect(isoScope.popoverTemplate).toEqual('templates/qr-scan-popover.jade')
+
+  it 'should display a warning when the camera cannot open', inject((Alerts) ->
+    spyOn(Alerts, 'displayWarning')
+    isoScope.cameraOn = true
+    isoScope.onCameraError()
+    expect(Alerts.displayWarning).toHaveBeenCalledWith('CAMERA_PERMISSION_DENIED')
+    expect(isoScope.cameraOn).toEqual(false)
+  )
+
+  it 'should call onScan with the payment request', ->
+    isoScope.onCameraResult('bitcoin:1JryFnzBdE8YRu6nDzZTZtyw9Sy4RbeABL')
+    expect(isoScope.onScan).toHaveBeenCalledWith(jasmine.objectContaining({
+      address: '1JryFnzBdE8YRu6nDzZTZtyw9Sy4RbeABL', isValid: true
+    }))
+    expect(isoScope.scanComplete).toEqual(true)
+    expect(isoScope.scanSuccess).toEqual(true)
+
+  it 'should not call onScan when there is a scan error', inject((Wallet) ->
+    Wallet.isValidAddress = () -> false
+    isoScope.onCameraResult('notbitcoin:asdfasdfasdf')
+    expect(isoScope.onScan).not.toHaveBeenCalled()
+    expect(isoScope.scanComplete).toEqual(true)
+    expect(isoScope.scanSuccess).toEqual(false)
+  )
+
+  it 'should reset after a scan', inject(($timeout) ->
+    isoScope.onCameraResult('bitcoin:1JryFnzBdE8YRu6nDzZTZtyw9Sy4RbeABL')
+    $timeout.flush()
+    expect(isoScope.cameraOn).toEqual(false)
+    expect(isoScope.scanComplete).toEqual(false)
+  )


### PR DESCRIPTION
@plondon we talked about adding something like this a few weeks ago, so I took a few minutes to put this together. All the functionality is there, but it might need some design help (in advanced send in particular).

- [x] fix QR processing in send when amount is present.
- [x] fix advanced send overflow issues (phil).
- [x] test for onAddressScan

![qr-scan-popup](https://cloud.githubusercontent.com/assets/8642682/13589118/71d2473c-e4a3-11e5-8df5-4c8d6fc34fca.png)