### PR TITLE
Allow custom API domain for fees and RNG

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -425,13 +425,13 @@ module.exports = (grunt) ->
           to: () =>
             'customWebSocketURL = "wss://' + @rootUrl + '/inv"'
         }]
-      fee_service_domain:
+      api_domain:
         src: ['build/js/services/wallet.service.js'],
         overwrite: true,
         replacements: [{
-          from: 'customFeeServiceDomain = $rootScope.feeServiceDomain'
+          from: 'customApiDomain = $rootScope.apiDomain'
           to: () =>
-            'customFeeServiceDomain = "https://' + @feeServiceDomain + '"'
+            'customApiDomain = "https://' + @apiDomain + '"'
         }]
       version_frontend:
         src: ['build/js/services/wallet.service.js'],
@@ -532,7 +532,7 @@ module.exports = (grunt) ->
 
 
 
-  grunt.registerTask "deploy", (versionFrontend, rootUrl, rootPath, feeServiceDomain) =>
+  grunt.registerTask "deploy", (versionFrontend, rootUrl, rootPath, apiDomain) =>
     if versionFrontend == undefined || versionFrontend[0] != "v"
       console.log "Missing version or version is missing 'v'"
       exit(1)
@@ -565,12 +565,12 @@ module.exports = (grunt) ->
         "replace:root_path"
       ]
 
-    if feeServiceDomain
-      @feeServiceDomain = feeServiceDomain
-      console.log("Custom dynamic fee domain: " + @feeServiceDomain)
+    if apiDomain
+      @apiDomain = apiDomain
+      console.log("Custom API domain: " + @apiDomain)
 
       grunt.task.run [
-        "replace:fee_service_domain"
+        "replace:api_domain"
       ]
 
     grunt.task.run [
@@ -593,7 +593,7 @@ module.exports = (grunt) ->
       "rename:html"
     ]
 
-  grunt.registerTask "dist_unsafe", (rootUrl, rootPath, feeServiceDomain) =>
+  grunt.registerTask "dist_unsafe", (rootUrl, rootPath, apiDomain) =>
     console.warn "Do not deploy this to production."
     console.warn "Make sure your bower_components and node_modules are up to date"
     grunt.task.run [
@@ -621,12 +621,12 @@ module.exports = (grunt) ->
           "replace:root_path"
         ]
 
-    if feeServiceDomain
-      @feeServiceDomain = feeServiceDomain
-      console.log("Custom dynamic fee domain: " + @feeServiceDomain)
+    if apiDomain
+      @apiDomain = apiDomain
+      console.log("Custom API domain: " + @apiDomain)
 
       grunt.task.run [
-        "replace:fee_service_domain"
+        "replace:api_domain"
       ]
 
     grunt.task.run [

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ Create a file called `.env` in the root of the project. Put the following in it:
 ROOT_URL=https://blockchain.info
 ```
 
+Optionally you can add:
+
+```
+AUTO_RELOAD=1
+ROOT_PATH=wallet-beta/
+WEBSOCKET_URL=wss://blockchain.info/inv
+API_DOMAIN=https://api.blockchain.info
+```
+
 ## Build
 
 Grunt watches and compiles the Jade view templates and CSS. Keep it running:
@@ -88,22 +97,6 @@ Did you know you can [sign your commits](https://git-scm.com/book/tr/v2/Git-Tool
 ## Testnet
 
 Not supported by the server yet.
-
-## Deploy
-
-Create a static HTML/JS/CSS distribution package in `dist`.
-
-    grunt dist
-
-If you get 403 error from Github (because you exceeded their rate limit), create a [personal access token](https://github.com/settings/tokens). Only select `public_repo` from the list.
-
-    GITHUB_USER=... GITHUB_TOKEN=... grunt dist
-
-If you don't care about securely downloading dependencies and want to avoid using your Github credentials, use `grunt dist_unsafe` instead.
-
-You can test the resulting files by setting `DIST=1` in `.env` and restarting the server.
-
-`index.html` should be cached using `If-Modified-Since` or `etag`. All other files contain a hash of their content and should be cached forever.
 
 ## Security
 

--- a/app/index.jade
+++ b/app/index.jade
@@ -1,5 +1,5 @@
 doctype
-<!-- @if !PRODUCTION --><html lang='en' ng-app='walletApp' ng-init="autoReload=#{ process.env.AUTO_RELOAD || false }; rootURL='#{ process.env.ROOT_URL }/'; rootPath='#{ process.env.ROOT_PATH }'; webSocketURL='#{ process.env.WEBSOCKET_URL }'; feeServiceDomain='#{ process.env.FEE_SERVICE_DOMAIN }';" ng-csp ng-class="{'not-fixed': outOfApp}"><!-- @endif -->
+<!-- @if !PRODUCTION --><html lang='en' ng-app='walletApp' ng-init="autoReload=#{ process.env.AUTO_RELOAD || false }; rootURL='#{ process.env.ROOT_URL }/'; rootPath='#{ process.env.ROOT_PATH }'; webSocketURL='#{ process.env.WEBSOCKET_URL }'; apiDomain='#{ process.env.API_DOMAIN }';" ng-csp ng-class="{'not-fixed': outOfApp}"><!-- @endif -->
 <!-- @if PRODUCTION !><html lang='en' ng-app='walletApp' ng-csp ng-class="{'not-fixed': outOfApp}"><!-- @endif -->
 head
   meta(charset='utf-8')
@@ -51,6 +51,7 @@ head
   script(src='bower_components/blockchain-wallet/dist/my-wallet.js')
   script(src='build/js/core/core.module.js')
   script(src='build/js/core/api.service.js')
+  script(src='build/js/core/rng.service.js')
   script(src='build/js/core/settings.service.js')
   script(src='build/js/core/store.service.js')
   script(src='build/js/core/myWallet.service.js')

--- a/assets/js/controllers/send.controller.js
+++ b/assets/js/controllers/send.controller.js
@@ -41,7 +41,7 @@ function SendCtrl($scope, $log, Wallet, Alerts, currency, $uibModalInstance, $ti
   $scope.payment = new Wallet.payment({ feePerKb: 30000 });
   $scope.transaction = angular.copy($scope.transactionTemplate);
 
-  let dynamicFeeService = $rootScope.feeServiceDomain + '/fees';
+  let dynamicFeeService = $rootScope.apiDomain + '/fees';
   let dynamicFeeVectorP = $http
     .get(dynamicFeeService)
     .then(response => response.data.estimate);

--- a/assets/js/core/rng.service.js
+++ b/assets/js/core/rng.service.js
@@ -1,0 +1,7 @@
+angular
+  .module('walletApp.core')
+  .factory('MyBlockchainRng', MyBlockchainRng);
+
+function MyBlockchainRng() {
+  return Blockchain.RNG;
+}

--- a/assets/js/services/wallet.service.js
+++ b/assets/js/services/wallet.service.js
@@ -9,9 +9,9 @@ angular
   .module('walletServices', [])
   .factory('Wallet', Wallet);
 
-Wallet.$inject = ['$http', '$window', '$timeout', '$location', 'Alerts', 'MyWallet', 'MyBlockchainApi', 'MyBlockchainSettings', 'MyWalletStore', 'MyWalletPayment', 'MyWalletHelpers', '$rootScope', 'ngAudio', '$cookies', '$translate', '$filter', '$state', '$q', 'bcPhoneNumber', 'languages', 'currency'];
+Wallet.$inject = ['$http', '$window', '$timeout', '$location', 'Alerts', 'MyWallet', 'MyBlockchainApi', 'MyBlockchainRng', 'MyBlockchainSettings', 'MyWalletStore', 'MyWalletPayment', 'MyWalletHelpers', '$rootScope', 'ngAudio', '$cookies', '$translate', '$filter', '$state', '$q', 'bcPhoneNumber', 'languages', 'currency'];
 
-function Wallet(   $http,   $window,   $timeout,  $location,  Alerts,   MyWallet,   MyBlockchainApi,   MyBlockchainSettings,   MyWalletStore,   MyWalletPayment,  MyWalletHelpers,   $rootScope,   ngAudio,   $cookies,   $translate,   $filter,   $state,   $q,   bcPhoneNumber,   languages,   currency) {
+function Wallet(   $http,   $window,   $timeout,  $location,  Alerts,   MyWallet,   MyBlockchainApi, MyBlockchainRng,  MyBlockchainSettings,   MyWalletStore,   MyWalletPayment,  MyWalletHelpers,   $rootScope,   ngAudio,   $cookies,   $translate,   $filter,   $state,   $q,   bcPhoneNumber,   languages,   currency) {
   const wallet = {
     goal: {
       auth: false
@@ -58,6 +58,7 @@ function Wallet(   $http,   $window,   $timeout,  $location,  Alerts,   MyWallet
   wallet.store = MyWalletStore;
 
   wallet.api = MyBlockchainApi;
+  wallet.rng = MyBlockchainRng;
 
   // If a custom rootURL is set by index.jade:
   //                    Grunt can replace this:
@@ -78,10 +79,13 @@ function Wallet(   $http,   $window,   $timeout,  $location,  Alerts,   MyWallet
     wallet.my.ws.wsUrl=customWebSocketURL;
   }
 
-  // If a custom feeServiceDomain is set by index.jade:
+  // If a custom apiDomain is set by index.jade:
   //                             Grunt can replace this:
-  const customFeeServiceDomain = $rootScope.feeServiceDomain || "https://api.blockchain.info";
-  $rootScope.feeServiceDomain = customFeeServiceDomain;
+  const customApiDomain = $rootScope.apiDomain || "https://api.blockchain.info";
+  $rootScope.apiDomain = customApiDomain;
+  if(customApiDomain) {
+    wallet.rng.URL=customApiDomain + "/v2/randombytes";
+  }
 
   // These are set by grunt dist:
   $rootScope.versionFrontend = null;

--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ var port      = process.env.PORT || 8080
   , whitelist = (process.env.IP_WHITELIST || '').split(' ')
   , rootURL   = process.env.ROOT_URL || 'https://blockchain.info/'
   , webSocketURL = process.env.WEBSOCKET_URL || false
-  , feeServiceDomain = process.env.FEE_SERVICE_DOMAIN
+  , apiDomain = process.env.API_DOMAIN
 
 // App configuration
 var app = express();
@@ -24,7 +24,7 @@ app.use(function (req, res, next) {
       "style-src 'self' 'sha256-vv5i1tRAGZ/gOQeRpI3CEWtvnCpu5FCixlD2ZPu7h84=' 'sha256-47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU='",
       "child-src 'none'",
       "script-src 'self' 'sha256-mBeSvdVuQxRa2pGoL8lzKX14b2vKgssqQoW36iRlU9g=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='",
-      "connect-src 'self' " + rootURL + " " + (webSocketURL || "wss://*.blockchain.info") + " https://api.blockchain.info" + (feeServiceDomain && feeServiceDomain.indexOf("api.blockchain.info") == -1 ? " " + feeServiceDomain : ""),
+      "connect-src 'self' " + rootURL + " " + (webSocketURL || "wss://*.blockchain.info") + " " + (apiDomain ||  "https://api.blockchain.info"),
       "object-src 'none'",
       "media-src 'self' data: mediastream: blob:",
       "font-src 'self'", ''

--- a/tests/mocks/my_wallet/my_blockchain_rng_mock.coffee
+++ b/tests/mocks/my_wallet/my_blockchain_rng_mock.coffee
@@ -1,0 +1,4 @@
+angular
+  .module('walletApp.core')
+  .factory('MyBlockchainRng', () -> {
+  })


### PR DESCRIPTION
It defaults to `api.blockchain.info` is used by the dynamic fees endpoint as well as the RNG endpoint.

The deploy script remains the same, but the last argument now refers to the API rather than the dynamic fees endpoint. 
