### PR TITLE
Send: translatable error messages

### DIFF
--- a/assets/js/controllers/send.controller.js
+++ b/assets/js/controllers/send.controller.js
@@ -447,7 +447,13 @@ function SendCtrl($scope, $log, Wallet, Alerts, currency, $uibModalInstance, $ti
       .then(fee => $scope.transaction.fee = fee)
       .then($scope.setAllAndBuild)
       .then(() => $scope.confirmationStep = true)
-      .catch(errorMsg => {
+      .catch(error => {
+        let errorMsg;
+        if(error.error) {
+          errorMsg = $translate.instant(error.error, error);
+        } else {
+          errorMsg = error;
+        }
         $scope.backToForm();
         Alerts.clear($scope.alerts);
         if (['cancelled', 'backdrop click', 'escape key press'].indexOf(errorMsg) === -1) {

--- a/locales/en-human.json
+++ b/locales/en-human.json
@@ -593,5 +593,9 @@
   "CONTINUE_WITH": "Continue with {{ suggested | convert }}",
   "BLOCK": "block",
   "BLOCKS": "blocks",
-  "SMALL_FEE_WARNING": "Your fee is so small that your transaction may never be confirmed."
+  "SMALL_FEE_WARNING": "Your fee is so small that your transaction may never be confirmed.",
+  "NO_UNSPENT_OUTPUTS" : "Missing coins to spend",
+  "BELOW_DUST_THRESHOLD" : "{{ amount  }} must be above dust threshold ({{ threshold }} Satoshis)",
+  "STRANGE_SCRIPT" : "Strange Script",
+  "CANNOT_DECODE_OUTPUT_ADDRESS" : "Unable to decode output address from transaction hash {{ tx_hash }}"
 }


### PR DESCRIPTION
Takes advantage of - but does not require - blockchain/My-Wallet-V3#169

@plondon @larskrueger you can now customize messages such as "No coins to spend"

cc @pernas 