### PR TITLE
Transaction List Performance

### DIFF
--- a/app/partials/transactions.jade
+++ b/app/partials/transactions.jade
@@ -2,20 +2,19 @@
   .filter-bar.flex-between.flex-center
     .filter-buttons.flex
       a.black.em-500.em-alt(
-        ng-repeat="f in filterTypes"
+        ng-repeat="f in filterTypes track by f"
         ng-click="setFilterType($index)"
         ng-class="{'active': isFilterType($index)}"
-        translate="{{ f }}"
-      )
+        translate="{{::f}}")
     .filter-search
       input(
         type="text"
         placeholder="{{::'SEARCH' | translate}}"
-        ng-model="searchText"
-        ng-model-options="{debounce: 500}")
+        ng-model="$parent.searchText"
+        ng-model-options="{ debounce: 250 }")
       i.ti-search
   .transaction-feed
-    .flex-center.flex-justify.flex-column.mtvl(ng-hide="loading || getTotal(accountIndex) > 0 || (transactions | filter:transactionFilter).length > 0 || selectedAccountIndex == 'imported'")
+    .flex-center.flex-justify.flex-column.mtvl(ng-hide="loading || getTotal(accountIndex) > 0 || filteredTransactions.length > 0 || selectedAccountIndex == 'imported'")
       .flex-column.mbl.border-bottom.black
         .flex-center.flex-justify
           i.ti-layout-list-post.h3.mrm
@@ -23,26 +22,26 @@
         p.em-400(translate="DESCRIBE_TRANSACTIONS")
       h3.em-100.center-align.mid-grey.emptystate(translate="HIT_RECEIVE", ng-click="request()")
       h3.em-100.center-align.mid-grey.emptystate(translate="HIT_SEND", ng-click="send()")
-    .flex-center.flex-justify.flex-column.mtl(ng-show="!loading && (transactions | filter:transactionFilter).length == 0 && getTotal(accountIndex) > 0 ")
+    .flex-center.flex-justify.flex-column.mtl(ng-show="!loading && filteredTransactions.length == 0 && getTotal(accountIndex) > 0 ")
       i.ti-search.h1.mrm
       h3.em-100.mbl(translate="SORRY_ZERO_TXS")
       p.em-400(translate="PLEASE_TRY_AGAIN", ng-click="supportModal()")
-    .transaction.no-select(ng-repeat="transaction in transactions | filter:transactionFilter | orderBy:'-time' track by $index")
-      .tx-toggle.hidden-xs.hidden-sm(ng-click="transaction.toggled = !transaction.toggled")
-        i.ti-arrow-circle-right.h4.ccc.pointer.mrl.prl(ng-show="!transaction.toggled")
-        i.ti-arrow-circle-down.h4.dark-grey.pointer.mrl.prl(ng-show="transaction.toggled")
+    .transaction.no-select(ng-repeat="tx in transactions | filter:transactionFilter | limitTo:txLimit as filteredTransactions track by tx.hash")
+      .tx-toggle.hidden-xs.hidden-sm(ng-click="tx.toggled = !tx.toggled")
+        i.ti-arrow-circle-right.h4.ccc.pointer.mrl.prl(ng-show="!tx.toggled")
+        i.ti-arrow-circle-down.h4.dark-grey.pointer.mrl.prl(ng-show="tx.toggled")
       .tx-details
-        .type.pointer(ng-click="showTransaction(transaction)")
+        .type.pointer(ng-click="showTransaction(tx)")
           span 
-            transaction-description(transaction="transaction" highlight="searchText" ng-if="canDisplayDescriptions")
+            transaction-description(transaction="tx" highlight="searchText" ng-if="canDisplayDescriptions")
       .amount
         span 
-          amount(transaction="transaction")
+          amount(transaction="tx")
     .row
       .col-xs-5
       .col-xs-2
-        p(align="center", ng-hide="loading || allTxsLoaded || (transactions | filter:transactionFilter).length == 0")
-          a(in-view="nextPage()", ng-click="nextPage()")
+        p(align="center" ng-hide="loading || allTxsLoaded || filteredTransactions.length == 0")
+          a(in-view="nextPage()" ng-click="nextPage()")
     .row(ng-show="loading").mtm.loading
        .col-xs-5
        .col-xs-2

--- a/app/templates/transaction-description.jade
+++ b/app/templates/transaction-description.jade
@@ -2,26 +2,22 @@
   .flex-align-end.flex-end.pbl
     .flex-column.col-md-3.col-sm-12.col-xs-12
       span.timestamp.pbm.type-sm.basic-grey
-        date {{ tx.time * 1000 | date:'MMMM d @ hh:mm a' }}
+        date {{:: tx.time * 1000 | date:'MMMM d @ hh:mm a' }}
       .flex-center
-        span.action(
-          ng-class="{\
-            incoming_tx : tx.txType === 'received',\
-            outgoing_tx : tx.txType === 'sent',\
-            local_tx    : tx.txType === 'transfer'\
-          }"
-          translate="{{ getAction(tx.txType) }}").prm
-        i.ti-notepad.aaa.plm(ng-show="tx.note").prm
-        span.label.label-default(translate="WATCH_ONLY", ng-show="((tx.txType === 'received' || tx.txType === 'transfer') && tx.toWatchOnly) ||  (tx.txType === 'sent' && tx.fromWatchOnly)")
+        span.action.prm(
+          ng-class=":: txClass"
+          translate="{{:: txDirection }}")
+        i.ti-notepad.aaa.plm.prm(ng-show="tx.note")
+        span.label.label-default(translate="WATCH_ONLY" ng-show=":: txWatchOnly")
     .hidden-xs.hidden-sm.destination.em-400.col-md-8(
       ng-class="tx.toggled ? 'dark-grey' : 'basic-grey'")
       .flex.row
         span.text.col-md-1(
-          ng-show="tx.txType === 'transfer' || tx.txType === 'received'") {{::'FROM' | translate}}:
+          ng-show=":: tx.txType === 'transfer' || tx.txType === 'received'") {{:: 'FROM' | translate}}:
         span.text.col-md-1(
-          ng-show="tx.txType === 'sent'") {{::'TO' | translate}}
+          ng-show=":: tx.txType === 'sent'") {{:: 'TO' | translate}}
         span.hidden-sm.hidden-xs.col-md-11.mlm(
-          ng-bind-html="getLabels(tx).primary | escapeHtml | highlight:search")
+          ng-bind-html="txLabels.primary | escapeHtml | highlight:search")
     .hidden-xs.hidden-sm.col-md-1
   .flex-center.border-top.ptl.hidden-xs.hidden-sm.dark-grey(
     ng-show="tx.toggled")
@@ -29,11 +25,11 @@
     .col-md-8.destination.em-400
       .flex.row
         span.text.col-md-1(
-          ng-show="tx.txType === 'transfer' || tx.txType === 'received'") {{::'TO' | translate}}:
+          ng-show=":: tx.txType === 'transfer' || tx.txType === 'received'") {{:: 'TO' | translate}}:
         span.text.col-md-1(
-          ng-show="tx.txType === 'sent'") {{::'FROM' | translate}}
+          ng-show=":: tx.txType === 'sent'") {{:: 'FROM' | translate}}
         span.hidden-sm.hidden-xs.col-md-11.mlm(
-          ng-bind-html="getLabels(tx).secondary | escapeHtml | highlight:search")
+          ng-bind-html="txLabels.secondary | escapeHtml | highlight:search")
       .flex.row.mtm(ng-show="tx.note")
         span.text.col-md-1(translate="NOTE_LC")
         span.break-word.hidden-sm.hidden-xs.col-md-11.mlm {{ tx.note }}

--- a/assets/js/controllers/transactions.controller.js
+++ b/assets/js/controllers/transactions.controller.js
@@ -14,6 +14,7 @@ function TransactionsCtrl($scope, Wallet, MyWallet, $timeout, $stateParams, $sta
   $scope.loading      = false;
   $scope.allTxsLoaded = false;
   $scope.canDisplayDescriptions = false;
+  $scope.txLimit      = 10;
 
   let accountIndex    = $stateParams.accountIndex;
   let txList          = MyWallet.wallet.txList;
@@ -34,7 +35,8 @@ function TransactionsCtrl($scope, Wallet, MyWallet, $timeout, $stateParams, $sta
   if ($scope.transactions.length === 0) fetchTxs();
 
   $scope.nextPage = () => {
-    if (!$scope.allTxsLoaded && !$scope.loading) fetchTxs();
+    if ($scope.txLimit < $scope.transactions.length) $scope.txLimit += 5;
+    else if (!$scope.allTxsLoaded && !$scope.loading) fetchTxs();
   };
 
   $scope.showTransaction = (transaction) => {
@@ -72,7 +74,7 @@ function TransactionsCtrl($scope, Wallet, MyWallet, $timeout, $stateParams, $sta
   };
 
   $scope.filterSearch = (tx, search) => {
-    if (search === '' || (search == null)) return true;
+    if (!search) return true;
     return ($scope.filterTx(tx.processedInputs, search) ||
             $scope.filterTx(tx.processedOutputs, search));
   };

--- a/assets/js/directives/transaction-description.directive.js
+++ b/assets/js/directives/transaction-description.directive.js
@@ -3,7 +3,7 @@ angular
   .module('walletApp')
   .directive('transactionDescription', transactionDescription);
 
-function transactionDescription($translate, $rootScope, Wallet, $compile, $sce) {
+function transactionDescription($translate, Wallet) {
   const directive = {
     restrict: 'E',
     replace: false,
@@ -17,13 +17,24 @@ function transactionDescription($translate, $rootScope, Wallet, $compile, $sce) 
   return directive;
 
   function link(scope, elem, attrs) {
-    scope.getAction = (txType) => {
+    scope.getTxDirection = (txType) => {
       if (txType === 'sent')      return 'SENT';
       if (txType === 'received')  return 'RECEIVED_BITCOIN_FROM';
       if (txType === 'transfer')  return 'MOVED_BITCOIN_TO';
     };
 
-    scope.getLabels = (tx) => {
+    scope.getTxClass = (txType) => {
+      if (txType === 'sent')      return 'outgoing_tx';
+      if (txType === 'received')  return 'incoming_tx';
+      if (txType === 'transfer')  return 'local_tx';
+    };
+
+    scope.getTxWatchOnly = (tx) => {
+      return ((tx.txType === 'received' || tx.txType === 'transfer') && tx.toWatchOnly) ||
+              (tx.txType === 'sent' && tx.fromWatchOnly);
+    };
+
+    scope.getTxLabels = (tx) => {
       if (!tx || !tx.processedInputs || !tx.processedOutputs) return;
 
       let formatted = Wallet.formatTransactionCoins(tx);
@@ -44,6 +55,11 @@ function transactionDescription($translate, $rootScope, Wallet, $compile, $sce) 
         secondary: scope.secondaryLabel = outputsLabel
       });
     };
+
+    scope.txDirection = scope.getTxDirection(scope.tx.txType);
+    scope.txClass = scope.getTxClass(scope.tx.txType);
+    scope.txWatchOnly = scope.getTxWatchOnly(scope.tx);
+    scope.txLabels = scope.getTxLabels(scope.tx);
 
     scope.$watch('search', (search) => {
       if (search == null) return;

--- a/tests/directives/transaction_description_spec.coffee
+++ b/tests/directives/transaction_description_spec.coffee
@@ -42,8 +42,27 @@ describe "Transaction Description Directive", ->
     $rootScope.$digest()
     isoScope = element.isolateScope()
 
-  it "should include incoming_tx class", ->
-    expect(element.html()).toContain 'incoming_tx'
+  describe "getTxDirection", ->
+
+    it "should have correct translation when sent", ->
+      expect(isoScope.getTxDirection('sent')).toEqual('SENT')
+
+    it "should have correct translation when received", ->
+      expect(isoScope.getTxDirection('received')).toEqual('RECEIVED_BITCOIN_FROM')
+
+    it "should have correct translation when transferred", ->
+      expect(isoScope.getTxDirection('transfer')).toEqual('MOVED_BITCOIN_TO')
+
+  describe "getTxClass", ->
+
+    it "should return outgoing_tx class when sent", ->
+      expect(isoScope.getTxClass('sent')).toEqual('outgoing_tx')
+
+    it "should return incoming_tx class when received", ->
+      expect(isoScope.getTxClass('received')).toEqual('incoming_tx')
+
+    it "should return local_tx class when transferred", ->
+      expect(isoScope.getTxClass('transfer')).toEqual('local_tx')
 
   it "should have the transaction in its scope", ->
     expect(isoScope.tx.hash).toBe("tx_hash")


### PR DESCRIPTION
Gets rid of any noticeable lag when navigating between / in transaction lists by:
* Adding one-way binding to expressions that don't need reevaluation to reduce watcher count
* Gradually rendering transactions on scroll
* Creating a filteredTransactions alias to prevent unnecessary list traversals