### PR TITLE
WalletService: use reorganized login() parameters

### DIFF
--- a/assets/js/controllers/login.controller.js
+++ b/assets/js/controllers/login.controller.js
@@ -49,6 +49,9 @@ function LoginCtrl ($scope, $rootScope, $location, $log, $http, Wallet, WalletNe
   if ($cookies.get('password')) {
     $scope.password = $cookies.get('password');
   }
+  if ($cookies.get('session')) {
+    $scope.sessionToken = $cookies.get('session');
+  }
   $scope.login = () => {
     if ($scope.busy) return;
     $scope.busy = true;
@@ -66,21 +69,28 @@ function LoginCtrl ($scope, $rootScope, $location, $log, $http, Wallet, WalletNe
         $scope.didEnterCorrect2FA = true;
       }
     };
-    const needs2FA = () => {
+    const needs2FA = (sessionToken) => {
+      $cookies.put('session', sessionToken);
       $scope.busy = false;
       $scope.didAsk2FA = true;
+      $scope.sessionToken = sessionToken;
     };
-    const success = () => {
+    const success = (guid, sessionToken) => {
+      $cookies.put('session', sessionToken);
       $scope.busy = false;
       if ($scope.autoReload && $cookies.get('reload.url')) {
         $location.url($cookies.get('reload.url'));
         $cookies.remove('reload.url');
       }
     };
+    if ($scope.uid !== $cookies.get('uid')) {
+      // Don't reuse the session token for a different wallet.
+      $scope.sessionToken = null;
+    }
     if ($scope.settings.needs2FA) {
-      Wallet.login($scope.uid, $scope.password, $scope.twoFactorCode, () => {}, success, error);
+      Wallet.login($scope.sessionToken, $scope.uid, $scope.password, $scope.twoFactorCode, () => {}, success, error);
     } else {
-      Wallet.login($scope.uid, $scope.password, null, needs2FA, success, error);
+      Wallet.login($scope.sessionToken, $scope.uid, $scope.password, null, needs2FA, success, error);
     }
     if ($scope.uid != null && $scope.uid !== '') {
       $cookies.put('uid', $scope.uid);
@@ -107,7 +117,7 @@ function LoginCtrl ($scope, $rootScope, $location, $log, $http, Wallet, WalletNe
         $scope.resending = false;
         $rootScope.$safeApply();
       };
-      WalletNetwork.resendTwoFactorSms($scope.uid).then(success).catch(error);
+      WalletNetwork.resendTwoFactorSms($scope.uid, $scope.sessionToken).then(success).catch(error);
     }
   };
 

--- a/assets/js/controllers/lostGuid.controller.js
+++ b/assets/js/controllers/lostGuid.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('LostGuidCtrl', LostGuidCtrl);
 
-function LostGuidCtrl ($scope, $rootScope, $http, $translate, WalletNetwork, Alerts) {
+function LostGuidCtrl ($scope, $rootScope, $http, $translate, WalletNetwork, Alerts, $sce) {
   $scope.currentStep = 1;
   $scope.fields = {
     email: '',
@@ -10,9 +10,14 @@ function LostGuidCtrl ($scope, $rootScope, $http, $translate, WalletNetwork, Ale
   };
 
   $scope.refreshCaptcha = () => {
-    let time = new Date().getTime();
-    $scope.captchaSrc = $rootScope.rootURL + `kaptcha.jpg?timestamp=${time}`;
-    $scope.fields.captcha = '';
+    WalletNetwork.getCaptchaImage().then((data) => {
+      let url = URL.createObjectURL(data.image);
+      $sce.trustAsResourceUrl(url);
+      $scope.captchaSrc = url;
+      $scope.sessionToken = data.sessionToken;
+      $scope.fields.captcha = '';
+      $rootScope.$safeApply();
+    });
   };
 
   $scope.sendReminder = () => {
@@ -45,7 +50,7 @@ function LostGuidCtrl ($scope, $rootScope, $http, $translate, WalletNetwork, Ale
     $scope.form.$setPristine();
     $scope.form.$setUntouched();
 
-    WalletNetwork.recoverGuid($scope.fields.email, $scope.fields.captcha).then(success).catch(error);
+    WalletNetwork.recoverGuid($scope.sessionToken, $scope.fields.email, $scope.fields.captcha).then(success).catch(error);
   };
 
   $scope.refreshCaptcha();

--- a/assets/js/controllers/navigation.controller.js
+++ b/assets/js/controllers/navigation.controller.js
@@ -34,12 +34,14 @@ function NavigationCtrl ($rootScope, $scope, Wallet, currency, SecurityCenter, $
       $scope.uid = null;
       $scope.password = null;
       $cookies.remove('password');
-//      $cookies.remove('uid') // Pending a 'Forget Me feature'
+      let sessionToken = $cookies.get('session');
+      $cookies.remove('session');
+//      $cookies.remove("uid") // Pending a "Forget Me feature"
 
       $state.go('wallet.common.transactions', {
         accountIndex: ''
       });
-      Wallet.logout();  // Refreshes the browser, so won't return
+      Wallet.logout(sessionToken);  // Refreshes the browser, so won't return
     });
   };
 

--- a/assets/js/controllers/recoverFunds.controller.js
+++ b/assets/js/controllers/recoverFunds.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('RecoverFundsCtrl', RecoverFundsCtrl);
 
-function RecoverFundsCtrl ($scope, $rootScope, $state, $timeout, $translate, Wallet, Alerts) {
+function RecoverFundsCtrl ($scope, $rootScope, $state, $timeout, $translate, $cookies, Wallet, Alerts) {
   $scope.isValidMnemonic = Wallet.isValidBIP39Mnemonic;
   $scope.currentStep = 1;
   $scope.fields = {
@@ -23,7 +23,10 @@ function RecoverFundsCtrl ($scope, $rootScope, $state, $timeout, $translate, Wal
       $scope.nextStep();
       $rootScope.$safeApply();
 
-      const loginSuccess = () => {
+      const loginSuccess = (guid, sessionToken) => {
+        $cookies.put('session', sessionToken);
+        $cookies.put('uid', guid);
+
         Alerts.displaySuccess('Successfully recovered wallet!');
       };
       const loginError = (err) => {
@@ -32,7 +35,7 @@ function RecoverFundsCtrl ($scope, $rootScope, $state, $timeout, $translate, Wal
       $timeout(() => {
         $state.go('public.login-uid', {uid: wallet.guid});
         Wallet.login(
-          wallet.guid, wallet.password, null, null, loginSuccess, loginError
+          null, wallet.guid, wallet.password, null, null, loginSuccess, loginError
         );
       }, 4000);
     };

--- a/assets/js/controllers/resetTwoFactor.controller.js
+++ b/assets/js/controllers/resetTwoFactor.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('ResetTwoFactorCtrl', ResetTwoFactorCtrl);
 
-function ResetTwoFactorCtrl ($scope, $rootScope, $http, $translate, WalletNetwork, Alerts) {
+function ResetTwoFactorCtrl ($scope, $rootScope, $http, $translate, WalletNetwork, Alerts, $sce) {
   $scope.currentStep = 1;
   $scope.fields = {
     email: '',
@@ -17,9 +17,14 @@ function ResetTwoFactorCtrl ($scope, $rootScope, $http, $translate, WalletNetwor
   });
 
   $scope.refreshCaptcha = () => {
-    let time = new Date().getTime();
-    $scope.captchaSrc = $rootScope.rootURL + `kaptcha.jpg?timestamp=${time}`;
-    $scope.fields.captcha = '';
+    WalletNetwork.getCaptchaImage().then((data) => {
+      let url = URL.createObjectURL(data.image);
+      $sce.trustAsResourceUrl(url);
+      $scope.captchaSrc = url;
+      $scope.sessionToken = data.sessionToken;
+      $scope.fields.captcha = '';
+      $rootScope.$safeApply();
+    });
   };
 
   $scope.resetTwoFactor = () => {
@@ -54,6 +59,7 @@ function ResetTwoFactorCtrl ($scope, $rootScope, $http, $translate, WalletNetwor
     $scope.form.$setUntouched();
 
     WalletNetwork.requestTwoFactorReset(
+      $scope.sessionToken,
       $scope.fields.uid,
       $scope.fields.email,
       $scope.fields.newEmail,

--- a/assets/js/controllers/signup.controller.js
+++ b/assets/js/controllers/signup.controller.js
@@ -58,10 +58,11 @@ function SignupCtrl ($scope, $state, $cookies, $filter, $translate, $uibModal, W
   $scope.signup = () => {
     if ($scope.signupForm.$valid) {
       $scope.working = true;
-      $scope.createWallet((uid) => {
+      $scope.createWallet((uid, sessionToken) => {
         $scope.working = false;
         if (uid != null) {
           $cookies.put('uid', uid);
+          $cookies.put('session', sessionToken);
         }
         if ($scope.autoReload) {
           $cookies.put('password', $scope.fields.password);
@@ -72,8 +73,8 @@ function SignupCtrl ($scope, $state, $cookies, $filter, $translate, $uibModal, W
   };
 
   $scope.createWallet = successCallback => {
-    Wallet.create($scope.fields.password, $scope.fields.email, $scope.currency_guess, $scope.language_guess, (uid) => {
-      successCallback(uid);
+    Wallet.create($scope.fields.password, $scope.fields.email, $scope.currency_guess, $scope.language_guess, (uid, sessionToken) => {
+      successCallback(uid, sessionToken);
     });
   };
 

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "browserdetection": "sjors/browser-detection#webkit",
     "bc-qr-reader": "0.2.*",
     "bootstrap-sass": "3.3.*",
-    "blockchain-wallet": "3.15 >=3.15.1",
+    "blockchain-wallet": "3.16.*",
     "bc-phone-number": "5.0.11"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
       "angular",
       "browserDetection",
       "Blockchain",
-      "compareVersions"
+      "compareVersions",
+      "URL"
     ]
   }
 }

--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ rootApp.use('/wallet', app);
 app.use(function (req, res, next) {
   if (req.url === '/') {
     var cspHeader = ([
-      "img-src 'self' " + rootURL + ' data:',
+      "img-src 'self' " + rootURL + ' data: blob:',
       // echo -n "outline: 0;" | openssl dgst -sha256 -binary | base64
       // "outline: 0;"        : ud+9... from ui-select
       // "margin-right: 10px" : 4If ... from ui-select

--- a/tests/controllers/login_ctrl_spec.coffee
+++ b/tests/controllers/login_ctrl_spec.coffee
@@ -45,10 +45,11 @@ describe "LoginCtrl", ->
 
   it "should resend two factor sms", inject((Wallet, WalletNetwork) ->
     Wallet.settings.twoFactorMethod = 5
+    scope.sessionToken = "token"
     scope.uid = "user"
 
     scope.resend()
 
     expect(WalletNetwork.resendTwoFactorSms).toHaveBeenCalled()
-    expect(WalletNetwork.resendTwoFactorSms).toHaveBeenCalledWith("user")
+    expect(WalletNetwork.resendTwoFactorSms).toHaveBeenCalledWith("user", "token")
   )

--- a/tests/controllers/lost_guid_ctrl_spec.coffee
+++ b/tests/controllers/lost_guid_ctrl_spec.coffee
@@ -9,7 +9,7 @@ describe "LostGuidCtrl", ->
       Wallet = $injector.get("Wallet")
       WalletNetwork = $injector.get("WalletNetwork")
 
-      WalletNetwork.recoverGuid = (email, captcha) -> {
+      WalletNetwork.recoverGuid = (token, email, captcha) -> {
         then: (callback) ->
           if captcha != ""
             callback()
@@ -19,6 +19,18 @@ describe "LostGuidCtrl", ->
                 callback()
           }
       }
+
+      WalletNetwork.getCaptchaImage = () -> {
+        then: (cb) ->
+          cb({
+            image: "captcha-image-blob",
+            sessionToken: "token"
+          })
+      }
+
+      window.URL =
+        createObjectURL: (blob) ->
+          blob + "_url"
 
       scope = $rootScope.$new()
 
@@ -68,7 +80,7 @@ describe "LostGuidCtrl", ->
 
     it "should call recoverGuid() with form data", ->
       scope.sendReminder()
-      expect(WalletNetwork.recoverGuid).toHaveBeenCalledWith("a@b.com", "1zabc")
+      expect(WalletNetwork.recoverGuid).toHaveBeenCalledWith("token", "a@b.com", "1zabc")
 
     it "should go to the next step", ->
       scope.sendReminder()

--- a/tests/controllers/reset_two_factor_ctrl_spec.coffee
+++ b/tests/controllers/reset_two_factor_ctrl_spec.coffee
@@ -9,7 +9,7 @@ describe "ResetTwoFactorCtrl", ->
       Wallet = $injector.get("Wallet")
       WalletNetwork = $injector.get("WalletNetwork")
 
-      WalletNetwork.requestTwoFactorReset = (uid) -> {
+      WalletNetwork.requestTwoFactorReset = (token, uid) -> {
         then: (callback) ->
           if uid != ""
             callback()
@@ -27,6 +27,18 @@ describe "ResetTwoFactorCtrl", ->
             catch: () ->
           }
       }
+
+      WalletNetwork.getCaptchaImage = () -> {
+        then: (cb) ->
+          cb({
+            image: "captcha-image-blob",
+            sessionToken: "token"
+          })
+      }
+
+      window.URL =
+        createObjectURL: (blob) ->
+          blob + "_url"
 
       scope = $rootScope.$new()
 
@@ -78,7 +90,7 @@ describe "ResetTwoFactorCtrl", ->
 
     it "should call requestTwoFactorReset() with form data", ->
       scope.resetTwoFactor()
-      expect(WalletNetwork.requestTwoFactorReset).toHaveBeenCalledWith("1234", "a@b.com", '', '', 'Help', '1zabc')
+      expect(WalletNetwork.requestTwoFactorReset).toHaveBeenCalledWith("token", "1234", "a@b.com", '', '', 'Help', '1zabc')
 
     it "should go to the next step", ->
       scope.resetTwoFactor()

--- a/tests/services/wallet_service_spec.coffee
+++ b/tests/services/wallet_service_spec.coffee
@@ -20,8 +20,13 @@ describe "walletServices", () ->
         success: (() ->),
         error: (() ->)}
 
-      Wallet.my.login = (uid, sharedKey, password, two_factor_code, didLogin) ->
-        didLogin()
+      Wallet.my.login = (uid, password, credentials, callbacks) ->
+        then: (cb) ->
+          cb({guid: "1234", sessionToken: "token"})
+          {
+            catch: () ->
+          }
+
 
       Wallet.my.wallet =
         isUpgradedToHD: true


### PR DESCRIPTION
`MyWallet.login()` is now a promise and takes a lot fewer parameters.

- [x] depends on blockchain/My-Wallet-V3#181