### PR TITLE
Compile controller tests from template cache

### DIFF
--- a/tests/controllers/account_form_ctrl_spec.coffee
+++ b/tests/controllers/account_form_ctrl_spec.coffee
@@ -40,8 +40,9 @@ describe "AccountFormCtrl", ->
       }
 
   beforeEach ->
-    angular.mock.inject ($rootScope, $controller, $compile) ->
+    angular.mock.inject ($rootScope, $controller, $compile, $templateCache) ->
       scope = $rootScope.$new()
+      template = $templateCache.get('partials/account-form.jade')
 
       $controller "AccountFormCtrl",
         $scope: scope
@@ -49,13 +50,8 @@ describe "AccountFormCtrl", ->
         $uibModalInstance: modalInstance
         account: Wallet.accounts()[0]
 
-      element = angular.element(
-        '<form role="form" name="accountForm" novalidate>' +
-        '<input type="text" name="new" ng-model="fields.name" is-valid="validate(fields.name)" maxlength="17" required />' +
-        '</form>'
-      )
       scope.model = { fields: { name: '' } }
-      $compile(element)(scope)
+      $compile(template)(scope)
 
       scope.$digest()
 

--- a/tests/controllers/request_ctrl_spec.coffee
+++ b/tests/controllers/request_ctrl_spec.coffee
@@ -8,7 +8,7 @@ describe "RequestCtrl", ->
   beforeEach angular.mock.module("walletApp")
 
   beforeEach ->
-    angular.mock.inject ($injector, $controller, $rootScope, $compile) ->
+    angular.mock.inject ($injector, $controller, $rootScope, $compile, $templateCache) ->
       Wallet = $injector.get("Wallet")
       MyWallet = $injector.get("MyWallet")
       currency = $injector.get('currency')
@@ -38,6 +38,7 @@ describe "RequestCtrl", ->
       currency.conversions.EUR = { conversion: 400000 }
 
       scope = $rootScope.$new()
+      template = $templateCache.get('partials/request.jade')
 
       $controller "RequestCtrl",
         $scope: scope,
@@ -47,14 +48,8 @@ describe "RequestCtrl", ->
         focus: false,
         hasLegacyAddress: false
 
-
-      element = angular.element(
-        '<form role="form" name="requestForm" novalidate>' +
-        '<input type="text" name="amount"   ng-model="fields.amount"  currency="{{fields.currency}}" />' +
-        '</form>'
-      )
       scope.model = { fields: {to: null, amount: '0', currency: Wallet.settings.currency, label: ""} }
-      $compile(element)(scope)
+      $compile(template)(scope)
 
       scope.$digest()
 

--- a/tests/controllers/settings_address_import_ctrl_spec.coffee
+++ b/tests/controllers/settings_address_import_ctrl_spec.coffee
@@ -11,7 +11,7 @@ describe "AddressImportCtrl", ->
   beforeEach angular.mock.module("walletApp")
 
   beforeEach ->
-    angular.mock.inject ($injector, $rootScope, $controller, $compile) ->
+    angular.mock.inject ($injector, $rootScope, $controller, $compile, $templateCache) ->
       Wallet = $injector.get("Wallet")
 
       Wallet.addAddressOrPrivateKey = (addressOrPrivateKey, bip38passphrase, success, error, cancel) ->
@@ -35,6 +35,7 @@ describe "AddressImportCtrl", ->
       }
 
       scope = $rootScope.$new()
+      template = $templateCache.get('partials/settings/import-address.jade')
 
       $controller "AddressImportCtrl",
         $scope: scope,
@@ -42,14 +43,8 @@ describe "AddressImportCtrl", ->
         $uibModalInstance: modalInstance
         address: null
 
-      element = angular.element(
-        '<form role="form" name="importForm" novalidate>' +
-        '<input type="textarea" name="privateKey"       ng-model="fields.addressOrPrivateKey"   is-valid="isValidAddressOrPrivateKey(fields.addressOrPrivateKey)"     ng-disabled="BIP38"    ng-change="importForm.privateKey.$setValidity(\'present\', true)"   required />' +
-        '<input type="password" name="bipPassphrase"    ng-model="fields.bip38passphrase"       ng-change="importForm.bipPassphrase.$setValidity(\'wrong\', true)"      ng-required="BIP38" />' +
-        '</form>'
-      )
       scope.model = { fields: {} }
-      $compile(element)(scope)
+      $compile(template)(scope)
 
       scope.$digest()
 

--- a/tests/controllers/settings_change_password_ctrl_spec.coffee
+++ b/tests/controllers/settings_change_password_ctrl_spec.coffee
@@ -11,7 +11,7 @@ describe "ChangePasswordCtrl", ->
   beforeEach angular.mock.module("walletApp")
 
   beforeEach ->
-    angular.mock.inject ($injector, $rootScope, $controller, $compile) ->
+    angular.mock.inject ($injector, $rootScope, $controller, $compile, $templateCache) ->
       Wallet = $injector.get("Wallet")
 
       Wallet.user = {
@@ -24,21 +24,15 @@ describe "ChangePasswordCtrl", ->
       )
 
       scope = $rootScope.$new()
+      template = $templateCache.get('partials/settings/change-password.jade')
 
       $controller "ChangePasswordCtrl",
         $scope: scope,
         $stateParams: {},
         $uibModalInstance: modalInstance
 
-      element = angular.element(
-        '<form role="form" name="passwordForm" novalidate>' +
-        '<input type="password" name="currentPassword"    ng-model="fields.currentPassword"   is-valid="isCorrectMainPassword(fields.currentPassword)"      required />' +
-        '<input type="password" name="password"           ng-model="fields.password"          is-valid="fields.password != uid  && !isUserEmail(fields.password) && !isCorrectMainPassword(fields.password)"  min-entropy="25" ng-maxlength="255" required />' +
-        '<input type="password" name="confirmation"       ng-model="fields.confirmation"      is-valid="fields.confirmation == fields.password"             required />' +
-        '</form>'
-      )
       scope.model = { fields: {} }
-      $compile(element)(scope)
+      $compile(template)(scope)
 
       scope.$digest()
 

--- a/tests/controllers/signup_controller_spec.coffee
+++ b/tests/controllers/signup_controller_spec.coffee
@@ -7,7 +7,7 @@ describe "SignupCtrl", ->
   beforeEach angular.mock.module("walletApp")
 
   beforeEach ->
-    angular.mock.inject ($injector, $rootScope, $controller, $compile) ->
+    angular.mock.inject ($injector, $rootScope, $controller, $compile, $templateCache) ->
       Wallet = $injector.get("Wallet")
 
       Wallet.login = (uid, pass, code, twoFactor, success, error) -> success()
@@ -17,24 +17,16 @@ describe "SignupCtrl", ->
         change_local_currency: () ->
       Wallet.changeCurrency = () ->
 
-
       scope = $rootScope.$new()
+      template = $templateCache.get('partials/signup.jade')
 
       $controller "SignupCtrl",
         $scope: scope,
         $stateParams: {},
         $uibModalInstance: modalInstance
 
-      element = angular.element(
-        '<form role="form" name="signupForm" novalidate>' +
-          '<input type="email"    name="email"          ng-model="fields.email"         required />' +
-          '<input type="password" name="password"       ng-model="fields.password"      min-entropy="25" ng-maxlength="255" required />' +
-          '<input type="password" name="confirmation"   ng-model="fields.confirmation"  is-valid="fields.confirmation == fields.password" required />' +
-          '<input type="checkbox" name="agreement"      ng-model="fields.acceptedAgreement" required />' +
-        '</form>'
-      )
       scope.model = { fields: { email: '', password: '', confirmation: '', acceptedAgreement: false } }
-      $compile(element)(scope)
+      $compile(template)(scope)
 
       scope.$digest()
 


### PR DESCRIPTION
Now these controllers will use the actual jade templates, rather than the handwritten html strings. This lets us catch errors in the markup and makes tests more maintainable.