### PR TITLE
Move angular-password-entropy dependency into frontend

### DIFF
--- a/app/index.jade
+++ b/app/index.jade
@@ -60,7 +60,6 @@ body(ng-controller="AppCtrl" ui-view="body" ng-mousemove="resetInactivityTime()"
   script(src='bower_components/angular-translate/angular-translate.js')
   script(src='bower_components/angular-translate-loader-static-files/angular-translate-loader-static-files.js')
   script(src='bower_components/angular-inview/angular-inview.js')
-  script(src='bower_components/angular-password-entropy/password-entropy.js')  
   script(src='bower_components/digits-trie/dist/digits-trie.js')
   script(src='bower_components/google-libphonenumber/dist/browser/libphonenumber.js')
   script(src='bower_components/bc-countries/dist/bc-countries.js')

--- a/app/templates/password-entropy.jade
+++ b/app/templates/password-entropy.jade
@@ -1,0 +1,9 @@
+.progress(ng-show="password")
+  .progress-bar(
+    ng-class="barColor"
+    role="progressbar"
+    aria-valuenow="{{score}}"
+    aria-valuemin="0"
+    aria-valuemax="100"
+    ng-style="{width:score+'%'}")
+    {{strength}}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -21,7 +21,6 @@ const modules = [
   'pascalprecht.translate',
   'bcTranslateStaticFilesLoader',
   'angular-inview',
-  'passwordEntropy',
   'webcam',
   'bcQrReader',
 

--- a/assets/js/directives/min-entropy.directive.js
+++ b/assets/js/directives/min-entropy.directive.js
@@ -1,0 +1,24 @@
+angular
+  .module('walletApp')
+  .directive('minEntropy', minEntropy);
+
+function minEntropy (MyWalletHelpers) {
+  const directive = {
+    restrict: 'A',
+    require: 'ngModel',
+    link: link
+  };
+  return directive;
+
+  function link (scope, elem, attrs, ctrl) {
+    let minimum = parseFloat(attrs.minEntropy);
+
+    let checkEntropy = (viewValue) => {
+      let score = MyWalletHelpers.scorePassword(viewValue);
+      ctrl.$setValidity('minEntropy', score > minimum);
+      return viewValue;
+    };
+
+    ctrl.$parsers.push(checkEntropy);
+  }
+}

--- a/assets/js/directives/password-entropy.directive.js
+++ b/assets/js/directives/password-entropy.directive.js
@@ -1,0 +1,37 @@
+angular
+  .module('walletApp')
+  .directive('passwordEntropy', passwordEntropy);
+
+function passwordEntropy (MyWalletHelpers) {
+  const directive = {
+    restrict: 'E',
+    scope: {
+      password: '='
+    },
+    templateUrl: 'templates/password-entropy.jade',
+    controller: passwordEntropyController
+  };
+  return directive;
+
+  function passwordEntropyController ($scope) {
+    $scope.score = 0;
+
+    const displayOptions = {
+      '0': ['progress-bar-danger', 'weak'],
+      '25': ['progress-bar-warning', 'regular'],
+      '50': ['progress-bar-info', 'normal'],
+      '75': ['progress-bar-success', 'strong']
+    };
+
+    $scope.setDisplay = (score) => {
+      let threshold = Object.keys(displayOptions).filter(threshold => threshold <= score).reverse()[0];
+      [$scope.barColor, $scope.strength] = displayOptions[threshold];
+    };
+
+    $scope.$watch('password', (newPw) => {
+      let score = MyWalletHelpers.scorePassword(newPw);
+      $scope.score = score > 100 ? 100 : score;
+      $scope.setDisplay($scope.score);
+    });
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,6 @@
     "angular-translate": "2.7.*",
     "angular-translate-loader-static-files": "2.7.*",
     "angular-inview": "1.5.*",
-    "angular-password-entropy": "0.1.*",
     "browserdetection": "0.3.*",
     "bc-qr-reader": "0.2.*",
     "bootstrap-sass": "3.3.*",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,8 +36,7 @@ module.exports = function (config) {
       'tests/directives/*.coffee',
       'tests/mocks/**/*.coffee',
       'tests/**/*.js',
-      'app/templates/*.jade',
-      'bower_components/angular-password-entropy/password-entropy.js'
+      'app/templates/*.jade'
     ],
 
     autoWatch: true,

--- a/tests/controllers/settings_change_password_ctrl_spec.coffee
+++ b/tests/controllers/settings_change_password_ctrl_spec.coffee
@@ -101,7 +101,7 @@ describe "ChangePasswordCtrl", ->
     describe "password", ->
 
       it "should display an error if the new password is too weak", ->
-        scope.passwordForm.password.$setViewValue('weak')
+        scope.passwordForm.password.$setViewValue('a')
         expect(scope.passwordForm.password.$error.minEntropy).toBe(true)
 
       it "should display an error if the new password is too long", ->

--- a/tests/directives/password-entropy_spec.coffee
+++ b/tests/directives/password-entropy_spec.coffee
@@ -1,0 +1,40 @@
+describe "passwordEntropy", ->
+  $scope = undefined
+  isoScope = undefined
+  MyWalletHelpers = undefined
+
+  beforeEach module("walletApp")
+
+  beforeEach inject((_$compile_, _$rootScope_, $injector) ->
+    $compile = _$compile_
+    $rootScope = _$rootScope_
+    scope = $rootScope.$new()
+    MyWalletHelpers = $injector.get('MyWalletHelpers')
+
+    $scope = $rootScope.$new()
+    $scope.fields = { password: '' }
+    element = $compile('<password-entropy password="fields.password"></password-entropy>')($scope)
+    $scope.$digest()
+    isoScope = element.isolateScope()
+  )
+
+  beforeEach ->
+    expect(isoScope.score).toEqual(0)
+    expect(isoScope.barColor).toEqual('progress-bar-danger')
+    expect(isoScope.strength).toEqual('weak')
+
+  it "should update the score when the password changes", ->
+    $scope.fields.password = 'a'
+    $scope.$digest()
+    expect(isoScope.score).toEqual(25)
+
+  it "should never set the score to above 100", ->
+    $scope.fields.password = 'asdfasdfasdfasdfasdfasdfasdf'
+    $scope.$digest()
+    expect(isoScope.score).toEqual(100)
+
+  it "should set the display values correctly", ->
+    $scope.fields.password = 'ab'
+    $scope.$digest()
+    expect(isoScope.barColor).toEqual('progress-bar-info')
+    expect(isoScope.strength).toEqual('normal')

--- a/tests/mocks/my_wallet/my_wallet_helpers.coffee
+++ b/tests/mocks/my_wallet/my_wallet_helpers.coffee
@@ -6,4 +6,6 @@ angular
         false
       privateKeyCorrespondsToAddress: () ->
         $q.resolve(true)
+      scorePassword: (pw) ->
+        (pw && pw.length || 0) * 25
     }


### PR DESCRIPTION
Adapted from repo owned by @pernas: https://github.com/pernas/angular-password-entropy

Easier to maintain if it's in the frontend codebase.