### PR TITLE
Prevent multiple logout timers from running at once

### DIFF
--- a/app/index.jade
+++ b/app/index.jade
@@ -60,8 +60,7 @@ head
 body(
   ui-view="body"
   ng-mousemove="onAction()"
-  ng-keypress="onAction()"
-)
+  ng-click="onAction()")
   noscript
     img(src="/img/logo-bw.png")
     h3 Please enable JavaScript to use the Blockchain Wallet

--- a/assets/js/controllers/wallet.controller.js
+++ b/assets/js/controllers/wallet.controller.js
@@ -24,7 +24,7 @@ function WalletCtrl ($scope, $rootScope, Wallet, $uibModal, $timeout, Alerts, $i
   $scope.lastAction = Date.now();
   $scope.onAction = () => $scope.lastAction = Date.now();
 
-  $scope.inactivityInterval = () => {
+  $scope.inactivityCheck = () => {
     if (!Wallet.status.isLoggedIn) return;
     let inactivityTimeSeconds = Math.round((Date.now() - $scope.lastAction) / 1000);
     let logoutTimeSeconds = Wallet.settings.logoutTimeMinutes * 60;
@@ -35,7 +35,8 @@ function WalletCtrl ($scope, $rootScope, Wallet, $uibModal, $timeout, Alerts, $i
     }
   };
 
-  $interval($scope.inactivityInterval, 1000);
+  $scope.inactivityInterval = $interval($scope.inactivityCheck, 1000);
+  $scope.$on('$destroy', () => $interval.cancel($scope.inactivityInterval));
 
   $rootScope.browserWithCamera = (navigator.getUserMedia || navigator.mozGetUserMedia || navigator.webkitGetUserMedia || navigator.msGetUserMedia) !== void 0;
 

--- a/tests/controllers/wallet_ctrl_spec.coffee
+++ b/tests/controllers/wallet_ctrl_spec.coffee
@@ -93,7 +93,6 @@ describe "WalletCtrl", ->
     )
 
   describe "auto logout", ->
-
     it "should reset the inactivity time", ->
       spyOn(Date, "now").and.returnValue(100)
       scope.inactivityTimeSeconds = 1
@@ -106,8 +105,14 @@ describe "WalletCtrl", ->
       Wallet.settings.logoutTimeMinutes = 10
       scope.lastAction = 100000
       spyOn(Alerts, 'confirm').and.callThrough()
-      scope.inactivityInterval()
+      scope.inactivityCheck()
       expect(Alerts.confirm).toHaveBeenCalled()
+    )
+
+    it "should clear the interval when the controller is destroyed", inject(($interval) ->
+      spyOn($interval, "cancel")
+      scope.$broadcast("$destroy")
+      expect($interval.cancel).toHaveBeenCalledWith(scope.inactivityInterval)
     )
 
   describe "HD upgrade", ->


### PR DESCRIPTION
Cancels the logout interval when scope is destroyed, fixes some weird behavior that I noticed with auto logout.