### PR TITLE
Translate alert message in template

### DIFF
--- a/app/partials/settings/change-password.jade
+++ b/app/partials/settings/change-password.jade
@@ -42,6 +42,6 @@ form(role="form" name="form" novalidate)
         required)
       span.help-block(translate="NO_MATCH" ng-show="form.confirmation.$error.isValid && form.confirmation.$touched")
   .form-group.mbn.has-error.pull-right.right-align
-    span.help-block {{ errors.unsuccessful }}
+    span.help-block {{ errors.unsuccessful | translate }}
     button.button-muted.mrm(ng-click="deactivate()" translate="CANCEL")
     button.button-success(ui-ladda="status.waiting" ng-click="change()" ng-disabled="form.$invalid" ladda-translate="CHANGE" data-style="expand-left")

--- a/app/templates/completed-level-tooltip.jade
+++ b/app/templates/completed-level-tooltip.jade
@@ -1,5 +1,5 @@
 div.flex-column
   .border-bottom.pbm
     i.ti-check.bright-green.h3.mts
-    p {{::message}}
-  p {{::content}}
+    p {{::message|translate}}
+  p {{::content|translate}}

--- a/app/templates/completed-level.jade
+++ b/app/templates/completed-level.jade
@@ -3,4 +3,4 @@
     img(ng-src="{{::img}}")
   p.bright-green
     i.ti-check.prm
-    span {{::message}}
+    span {{::message|translate}}

--- a/assets/js/controllers/settings/changePassword.controller.js
+++ b/assets/js/controllers/settings/changePassword.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('ChangePasswordCtrl', ChangePasswordCtrl);
 
-function ChangePasswordCtrl ($scope, $log, Wallet, Alerts, $translate) {
+function ChangePasswordCtrl ($scope, $log, Wallet, Alerts) {
   $scope.isCorrectMainPassword = Wallet.isCorrectMainPassword;
   $scope.uid = Wallet.user.uid;
 
@@ -27,7 +27,7 @@ function ChangePasswordCtrl ($scope, $log, Wallet, Alerts, $translate) {
 
     const error = (err) => {
       $scope.status.waiting = false;
-      $translate(err).then(msg => $scope.errors.unsuccessful = msg);
+      $scope.errors.unsuccessful = err;
     };
 
     $scope.status.waiting = true;

--- a/assets/js/directives/completed-level.directive.js
+++ b/assets/js/directives/completed-level.directive.js
@@ -3,9 +3,9 @@ angular
   .module('walletApp')
   .directive('completedLevel', completedLevel);
 
-completedLevel.$inject = ['$translate'];
+completedLevel.$inject = [];
 
-function completedLevel ($translate) {
+function completedLevel () {
   const directive = {
     restrict: 'E',
     replace: true,
@@ -21,12 +21,6 @@ function completedLevel ($translate) {
   return directive;
 
   function link (scope, elem, attrs) {
-    $translate(scope.content).then((translation) => {
-      scope.content = translation;
-    });
-    $translate(scope.message).then((translation) => {
-      scope.message = translation;
-    });
     scope.tooltip = {
       templateUrl: 'templates/completed-level-tooltip.jade',
       placement: scope.placement || 'top'

--- a/assets/js/services/alerts.service.js
+++ b/assets/js/services/alerts.service.js
@@ -40,13 +40,14 @@ function Alerts ($timeout, $rootScope, $translate, $uibModal) {
   }
 
   function display (type, message, keep = false, context = service.alerts) {
-    $translate(message).then(translation => {
+    let displayAlert = (translation) => {
       let alert = { type: type, msg: translation };
       if (isDuplicate(context, alert)) return;
       alert.close = close.bind(null, alert, context);
       if (!keep) alert.timer = $timeout(() => alert.close(), 7000);
       context.push(alert);
-    });
+    };
+    $translate(message).then(displayAlert, () => displayAlert(message));
   }
 
   function displayVerifiedEmail () {


### PR DESCRIPTION
In the latest version of angular-translate, `$translate()` will only resolve if it can find a matching translation string, otherwise it will reject. This is a change from the previous version we were on, which would resolve with the argument (even if it wasn't a translation string). This caused alerts to not display in cases where we don't have translation strings in place.

This commit makes it so the alert will display even if no translation string is found.