### PR TITLE
tx-notes no longer able to have one long word overlapping

### DIFF
--- a/app/templates/transaction-note.jade
+++ b/app/templates/transaction-note.jade
@@ -1,6 +1,6 @@
 .flex-column.note.em-300.width-80
   .flex-row.flex-end.flex-start-tablet
-    .flex-row(ng-hide="editNote")
+    .flex-row.width-100(ng-hide="editNote")
       .tx-note.aaa.em-400.text-cursor(ng-show="label && !transaction.note") {{ label }}
       .tx-note.basic-grey.em-400.text-cursor(ng-hide="label && !transaction.note"
                                              ng-bind-html="transaction.note | escapeHtml | highlight:search")

--- a/assets/css/modules/_transaction-list.scss
+++ b/assets/css/modules/_transaction-list.scss
@@ -105,6 +105,10 @@
   .feed-details {
     border-top: 1px solid $eee;
   }
+  .tx-note {
+    max-width: 100%;
+    word-wrap: break-word;
+  }
 }
 
 .transaction-card {


### PR DESCRIPTION
In tx feed, one can no-longer have a single, long word which covers other elements