### PR TITLE
fix(Recover Funds, step 2): form invalidation no longer stops button

### DIFF
--- a/app/partials/recover-funds.jade
+++ b/app/partials/recover-funds.jade
@@ -1,4 +1,4 @@
-.pos-rel(ng-switch="currentStep")
+.recover-funds.pos-rel(ng-switch="currentStep")
   p.type-xs.em-500.step.pos-abs(ng-switch-when="1" translate="STEP_1_RECOVER")
   p.type-xs.em-500.step.pos-abs(ng-switch-when="2" translate="STEP_2_RECOVER")
   header.flex-center.flex-between
@@ -34,7 +34,7 @@
         ng-click="nextStep()"
         ng-disabled="!passphraseForm.$valid || browser.disabled"
         translate="CONTINUE")
-  form.ptl.form-horizontal(name="recoveryForm" ng-switch-when="2")
+  form.rf-step-2.ptl.form-horizontal(name="recoveryForm" ng-switch-when="2")
     div
       .form-group(ng-class="{'has-error': recoveryForm.email.$invalid && recoveryForm.email.$touched}")
         label.em-500(translate="EMAIL")

--- a/assets/css/modules/_signin.scss
+++ b/assets/css/modules/_signin.scss
@@ -120,3 +120,9 @@ div.login-form {
     .form-group { margin-bottom: 0; }
   }
 }
+
+.recover-funds {
+  .rf-step-2 .flex-center .button-muted{ 
+      min-height: 45px;
+  }
+}


### PR DESCRIPTION
clicking off of empty input would shift the relative elements down enough that the button wasn't within the original click range. increasing the button's height allows user to click off the default input box and still trigger the back button.