### PR TITLE
fix(Bank Transfer): remove binding to prop and val so trade can update

### DIFF
--- a/app/partials/trade-summary.jade
+++ b/app/partials/trade-summary.jade
@@ -5,5 +5,5 @@ div
     label.em-500.flex-start.pts.mtl(translate="{{isKYC || needsKyc() ? 'DETAILS' : 'ORDER_DETAILS'}}")
     ul.em-300(ng-if="formattedTrade.tx")
       li.pam.border-right.border-left.border-bottom-light.flex-between(ng-repeat="(prop, val) in formattedTrade.tx track by $index" ng-if="val" ng-class="{'border-top': $first}")
-        span.em-400.colon(translate="{{::prop}}")
-        span.em-400.right-align(ng-bind="::val")
+        span.em-400.colon(translate="{{prop}}")
+        span.em-400.right-align(ng-bind="val")


### PR DESCRIPTION
Although this will never actually be an issue IRL because bank transfers take a day or more and I doubt people will leave this modal open for that long, it will help QA. Need to remove the bindings so that the actual tx values update when the trade goes from pending user action to pending coinify action.