### PR TITLE
Prevent blank page when refreshing on settings/:account/addresses

### DIFF
--- a/assets/js/routes.js
+++ b/assets/js/routes.js
@@ -332,9 +332,14 @@ function AppRouter ($stateProvider, $urlRouterProvider) {
         }
       },
       resolve: {
-        paymentRequests: ($stateParams, $q, Wallet) => {
-          let index = parseInt($stateParams.account, 10);
-          return Wallet.getPendingPayments(index).catch(() => $q.reject('LOAD_ADDR_ERR'));
+        paymentRequests: ($stateParams, $q, $injector) => {
+          try {
+            let Wallet = $injector.get('Wallet');
+            let index = parseInt($stateParams.account, 10);
+            return Wallet.getPendingPayments(index).catch(() => $q.reject('LOAD_ADDR_ERR'));
+          } catch (e) {
+            return $q.resolve([]);
+          }
         }
       }
     })


### PR DESCRIPTION
Angular UI Router would silently throw an error and freeze up, since it wasn't able to resolve Wallet.