### PR TITLE
Isolate scopes to prevent opening contextual message simultaneously

### DIFF
--- a/assets/js/directives/buy-alert.directive.js
+++ b/assets/js/directives/buy-alert.directive.js
@@ -8,6 +8,7 @@ function buyAlert ($cookies) {
   const directive = {
     restrict: 'E',
     replace: true,
+    scope: {},
     templateUrl: 'templates/buy-alert.jade',
     link: link
   };

--- a/assets/js/directives/contextual-message.directive.js
+++ b/assets/js/directives/contextual-message.directive.js
@@ -9,6 +9,7 @@ function contextualMessage ($cookies, $window, Wallet, SecurityCenter, filterFil
   const directive = {
     restrict: 'E',
     replace: true,
+    scope: {},
     templateUrl: 'templates/contextual-message.jade',
     link: link
   };

--- a/tests/directives/buy-alert_spec.coffee
+++ b/tests/directives/buy-alert_spec.coffee
@@ -10,16 +10,13 @@ describe "Buy alert message", ->
   beforeEach inject((_$compile_, _$rootScope_, $injector) ->
     $compile = _$compile_
     $rootScope = _$rootScope_
-    scope = $rootScope.$new()
-
     $cookies = $injector.get("$cookies")
 
-    return
+    element = $compile("<buy-alert></buy-alert>")($rootScope)
+    $rootScope.$digest()
+    scope = element.isolateScope()
+    scope.$digest()
   )
-
-  beforeEach ->
-    element = $compile("<buy-alert></buy-alert>")(scope)
-    scope.$apply()
 
   it "should dismiss the message", ->
     spyOn($cookies, 'put')

--- a/tests/directives/contextual-message_spec.coffee
+++ b/tests/directives/contextual-message_spec.coffee
@@ -10,7 +10,6 @@ describe "Contextual message directive", ->
   beforeEach inject((_$compile_, _$rootScope_, $injector) ->
     $compile = _$compile_
     $rootScope = _$rootScope_
-    scope = $rootScope.$new()
 
     $cookies = $injector.get("$cookies")
     Wallet = $injector.get("Wallet")
@@ -27,10 +26,6 @@ describe "Contextual message directive", ->
 
     Wallet.status.isLoggedIn = true
 
-    return
-  )
-
-  beforeEach ->
     spyOn($cookies, "getObject").and.returnValue({ when: 1000 })
     spyOn(Wallet, "total").and.returnValue(1)
     spyOn(Date, "now").and.returnValue(1001)
@@ -38,8 +33,11 @@ describe "Contextual message directive", ->
     Wallet.status.needs2FA = false
     Wallet.user.isEmailVerified = false
 
-    element = $compile("<div><contextual-message></contextual-message></div>")(scope)
-    scope.$apply()
+    element = $compile("<div><contextual-message></contextual-message></div>")($rootScope)
+    $rootScope.$digest()
+    scope = element.children().isolateScope()
+    scope.$digest()
+  )
 
   it "has a 2 preset messages", ->
     expect(scope.presets.length).toEqual(2)


### PR DESCRIPTION
The two directives did not have isolated scopes, so they were essentially sharing the variables that determined when they were open.