### PR TITLE
Buy page should use same rules as tab for when to show

### DIFF
--- a/app/partials/wallet-navigation.jade
+++ b/app/partials/wallet-navigation.jade
@@ -8,7 +8,7 @@
       a(ui-sref="wallet.common.transactions")
         i.ti-layout-list-post
         span(translate="MY_TRANSACTIONS")
-
+    // Don't forget to update controllers/buySell.controller.js
     li.header(ui-sref-active="current" ng-show="(isCountryWhitelisted && isUserInvited) || userHasAccount()")
       span(ng-show="!userHasAccount()")
         buy-alert

--- a/assets/js/controllers/buySell.controller.js
+++ b/assets/js/controllers/buySell.controller.js
@@ -2,7 +2,21 @@ angular
   .module('walletApp')
   .controller('BuySellCtrl', BuySellCtrl);
 
-function BuySellCtrl ($rootScope, $scope, $state, Alerts, Wallet, currency, buySell, MyWallet, $cookies) {
+function BuySellCtrl ($rootScope, Options, $scope, $state, Alerts, Wallet, currency, buySell, MyWallet, $cookies) {
+  // Invite-only phase, remove after full release:
+  let accountInfo = MyWallet.wallet.accountInfo;
+  let whitelist = Options.options.showBuySellTab || [];
+  let countryInWhitelist = whitelist.indexOf(accountInfo.countryCodeGuess) > -1;
+  let isCountryWhitelisted = accountInfo && countryInWhitelist;
+  let isUserInvited = accountInfo && accountInfo.invited;
+  let userHasAccount = MyWallet.wallet.external && MyWallet.wallet.external.coinify.hasAccount;
+
+  if (!((isCountryWhitelisted && isUserInvited) || userHasAccount)) {
+    $state.go('wallet.common.home');
+    return;
+  }
+  // End of invite-only code
+
   $scope.buySellStatus = buySell.getStatus;
   $scope.trades = buySell.trades;
   $cookies.put('buy-alert-seen', true);

--- a/assets/js/controllers/wallet.controller.js
+++ b/assets/js/controllers/wallet.controller.js
@@ -96,11 +96,7 @@ function WalletCtrl ($scope, $rootScope, Wallet, $uibModal, $timeout, Alerts, $i
 
   $scope.$on('$stateChangeStart', (event, toState, toParams, fromState, fromParams) => {
     let wallet = MyWallet.wallet;
-    let isUserInvited = wallet && wallet.accountInfo && wallet.accountInfo.invited;
     if ($scope.isPublicState(toState.name) && Wallet.status.isLoggedIn) {
-      event.preventDefault();
-    }
-    if (!isUserInvited && toState.name === 'wallet.common.buy-sell') {
       event.preventDefault();
     }
     if (wallet && wallet.isDoubleEncrypted && toState.name === 'wallet.common.buy-sell') {


### PR DESCRIPTION
For users with an account, but who's email address is not whitelisted (e.g. because they changed it) the production wallet currently has a bug. It will show the tab, but clicking on it won't work, because the routes file still uses the old rules.

This would also allow users in other countries to manually navigate to the buy tab, provided their email is whitelisted.

This fix still has duplicate code, so may need some refactoring.