### PR TITLE
New buy-sell tab rules

### DIFF
--- a/assets/js/controllers/buySell.controller.js
+++ b/assets/js/controllers/buySell.controller.js
@@ -2,21 +2,7 @@ angular
   .module('walletApp')
   .controller('BuySellCtrl', BuySellCtrl);
 
-function BuySellCtrl ($rootScope, Options, $scope, $state, Alerts, Wallet, currency, buySell, MyWallet, $cookies) {
-  // Invite-only phase, remove after full release:
-  let accountInfo = MyWallet.wallet.accountInfo;
-  let whitelist = Options.options.showBuySellTab || [];
-  let countryInWhitelist = whitelist.indexOf(accountInfo.countryCodeGuess) > -1;
-  let isCountryWhitelisted = accountInfo && countryInWhitelist;
-  let isUserInvited = accountInfo && accountInfo.invited;
-  let userHasAccount = MyWallet.wallet.external && MyWallet.wallet.external.coinify.hasAccount;
-
-  if (!((isCountryWhitelisted && isUserInvited) || userHasAccount)) {
-    $state.go('wallet.common.home');
-    return;
-  }
-  // End of invite-only code
-
+function BuySellCtrl ($rootScope, $scope, $state, Alerts, Wallet, currency, buySell, MyWallet, $cookies) {
   $scope.buySellStatus = buySell.getStatus;
   $scope.trades = buySell.trades;
   $cookies.put('buy-alert-seen', true);

--- a/assets/js/controllers/buySellSelectPartner.controller.js
+++ b/assets/js/controllers/buySellSelectPartner.controller.js
@@ -2,7 +2,14 @@ angular
   .module('walletApp')
   .controller('BuySellSelectPartnerController', BuySellSelectPartnerController);
 
-function BuySellSelectPartnerController ($scope, $state, MyWallet, buySell, country, options) {
+function BuySellSelectPartnerController ($scope, $state, MyWallet, buySell, country, options, buyStatus) {
+  buyStatus.canBuy().then((canBuy) => {
+    if (!canBuy) {
+      $state.go('wallet.common.home');
+      return;
+    }
+  });
+
   let contains = (val, list) => list.indexOf(val) > -1;
   let codeGuess = MyWallet.wallet.accountInfo && MyWallet.wallet.accountInfo.countryCodeGuess;
 
@@ -10,7 +17,7 @@ function BuySellSelectPartnerController ($scope, $state, MyWallet, buySell, coun
   $scope.country = $scope.countries.filter(c => c.Code === codeGuess)[0];
 
   $scope.coinifyWhitelist = options.partners.coinify.countries;
-  $scope.sfoxWhitelist = ['US'];
+  $scope.sfoxWhitelist = options.partners.sfox.countries;
 
   $scope.partners = {
     'coinify': {

--- a/rootApp/Resources/wallet-options-debug.json
+++ b/rootApp/Resources/wallet-options-debug.json
@@ -8,6 +8,9 @@
                     "MC", "NL", "NO", "PL", "PT", "RE", "BL", "MF", "PM", "SM",
                     "SK", "SI", "ES", "SE", "CH"
                   ]
+    },
+    "sfox": {
+      "countries": ["US"]
     }
   }
 }

--- a/rootApp/Resources/wallet-options.json
+++ b/rootApp/Resources/wallet-options.json
@@ -8,6 +8,9 @@
                     "MC", "NL", "NO", "PL", "PT", "RE", "BL", "MF", "PM", "SM",
                     "SK", "SI", "ES", "SE", "CH"
                   ]
+    },
+    "sfox": {
+      "countries": []
     }
   }
 }

--- a/tests/controllers/buy_sell_select_partner_ctrl_spec.coffee
+++ b/tests/controllers/buy_sell_select_partner_ctrl_spec.coffee
@@ -26,6 +26,7 @@ describe "BuySellSelectPartnerController", ->
 
     options = partners:
       coinify: countries: ["GB"]
+      sfox: countries: ["US"]
 
     $controller "BuySellSelectPartnerController",
       $scope: $scope


### PR DESCRIPTION
Please double check my logic here...

* get sfoxWhitelist from config file
* always show buy-sell tab for Coinify countries
* move redirect to buySellSelectPartner controller
* buyStatus.canBuy() also returns true if user has an account