### PR TITLE
Remove input restrictions when removing 2nd pw

### DIFF
--- a/app/partials/settings/manage-second-password.jade
+++ b/app/partials/settings/manage-second-password.jade
@@ -7,8 +7,8 @@ form(role="form" name="form" novalidate data-preflight-tag="ChangeSecondPassword
         name="password"
         ng-model="fields.password"
         ng-change="fields.confirmation = ''"
-        minlength="4"
-        is-valid="!isPasswordHint(fields.password) && !isMainPassword(fields.password)"
+        ng-minlength="settings.secondPassword ? 0 : 4"
+        is-valid="settings.secondPassword || (!isPasswordHint(fields.password) && !isMainPassword(fields.password))"
         required
         focus-when="active && !settings.secondPassword")
       span.help-block(ng-show="form.password.$touched")


### PR DESCRIPTION
Fixes the issue where a user can be prevented from removing 2nd password if their password hint or main password is somehow the same (might've been set that way on legacy).