### PR TITLE
Show success modal when bitcoin is received

### DIFF
--- a/assets/js/controllers/sfox/sfoxCheckout.controller.js
+++ b/assets/js/controllers/sfox/sfoxCheckout.controller.js
@@ -54,10 +54,16 @@ function SfoxCheckoutController ($scope, $timeout, $q, Wallet, MyWalletHelpers, 
 
   $scope.buy = () => {
     $scope.lock();
+
+    let success = (trade) => {
+      sfox.watchTrade(trade);
+      modals.openTradeSummary(trade, 'initiated');
+      $scope.resetFields();
+    };
+
     $q.resolve($scope.quote.getPaymentMediums())
       .then(mediums => mediums.ach.buy($scope.account))
-      .then(trade => { modals.openTradeSummary(trade, 'initiated'); })
-      .then($scope.resetFields)
+      .then(success)
       .catch(() => { Alerts.displayError('Error connecting to our exchange partner'); })
       .then($scope.disableBuy)
       .finally($scope.free);

--- a/assets/js/services/wallet.service.js
+++ b/assets/js/services/wallet.service.js
@@ -166,6 +166,7 @@ function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWalle
         }
         wallet.status.isLoggedIn = true;
         $injector.get('buySell'); // init buySell to monitor incoming payments
+        $injector.get('sfox').init(MyWallet.wallet.external.sfox); // init sfox to monitor incoming payments
         $rootScope.$safeApply();
         successCallback && successCallback(result.guid);
       });

--- a/tests/controllers/sfox/sfox_checkout_ctrl.coffee
+++ b/tests/controllers/sfox/sfox_checkout_ctrl.coffee
@@ -11,7 +11,10 @@ describe "SfoxCheckoutController", ->
   Wallet = undefined
   MyWallet = undefined
 
-  mockTrade = () -> 'TRADE'
+  mockTrade = () ->
+    id: 'TRADE'
+    refresh: () ->
+    watchTrade: () ->
 
   mockMediums = () ->
     ach:
@@ -132,7 +135,8 @@ describe "SfoxCheckoutController", ->
       spyOn(modals, "openTradeSummary")
       scope.buy()
       scope.$digest()
-      expect(modals.openTradeSummary).toHaveBeenCalledWith('TRADE', 'initiated')
+      trade = jasmine.objectContaining({ id: "TRADE" })
+      expect(modals.openTradeSummary).toHaveBeenCalledWith(trade, 'initiated')
 
     it "should show an alert in case of error", ->
       spyOn(Alerts, "displayError")

--- a/tests/services/wallet_service_spec.coffee
+++ b/tests/services/wallet_service_spec.coffee
@@ -65,6 +65,8 @@ describe "walletServices", () ->
           email: "steve@me.com"
           mobile: "+1234"
           currency: "USD"
+        external:
+          sfox: { monitorPayments: -> }
 
       return
 


### PR DESCRIPTION
Won't work correctly until https://github.com/blockchain/bitcoin-sfox-client/pull/1 is merged.

* Start watching for SFOX trade txs after login
* Refresh trade before trade summary is opened to load amount
* Watch trade after checkout

Starting to see some duplication between this and Coinify, will work on minimizing that next week.