### PR TITLE
Show invite form to percentage of users

### DIFF
--- a/app/partials/wallet-navigation.jade
+++ b/app/partials/wallet-navigation.jade
@@ -9,15 +9,20 @@
         i.ti-layout-list-post
         span(translate="MY_TRANSACTIONS")
     // Don't forget to update controllers/buySell.controller.js
-    li.header(ui-sref-active="current" ng-show="canBuy || userHasAccount")
+    li.header(ui-sref-active="current" ng-show="canBuy || shouldShowInviteForm")
       pulse-cta(
-        active-when="shouldShowBuyCta()"
+        active-when="shouldShowBuyCta() && !shouldShowInviteForm"
         on-dismiss="setBuyCtaDismissed()"
         message-text="BUY_BITCOIN_ALERT"
         button-text="BUY_BITCOIN"
         route="wallet.common.buy-sell"
         color="green")
-      a(ui-sref="wallet.common.buy-sell")
+      a(ng-hide="shouldShowInviteForm"
+        ui-sref="wallet.common.buy-sell")
+        i.ti-direction-alt
+        span(translate="BUY_BITCOIN")
+      a(ng-show="shouldShowInviteForm"
+        ng-click="showInviteForm()")
         i.ti-direction-alt
         span(translate="BUY_BITCOIN")
 

--- a/assets/js/controllers/buySellSelectPartner.controller.js
+++ b/assets/js/controllers/buySellSelectPartner.controller.js
@@ -42,7 +42,7 @@ function BuySellSelectPartnerController ($scope, $state, MyWallet, buySell, coun
 
   $scope.onWhitelist = (countryCode) => (
     (contains(countryCode, $scope.coinifyWhitelist) && 'coinify') ||
-    (contains(countryCode, $scope.sfoxWhitelist) && 'sfox') || false
+    (contains(countryCode, $scope.sfoxWhitelist) && codeGuess === 'US' && 'sfox') || false
   );
 
   $scope.$watch('country', (c) => {

--- a/assets/js/controllers/walletNavigation.controller.js
+++ b/assets/js/controllers/walletNavigation.controller.js
@@ -8,6 +8,11 @@ function WalletNavigationCtrl ($rootScope, $scope, Wallet, SecurityCenter, $stat
   $scope.security = SecurityCenter.security;
   $scope.userHasAccount = buyStatus.userHasAccount();
 
+  // TODO: remove me
+  buyStatus.shouldShowInviteForm().then((res) => {
+    console.log('Should show form?', res);
+  });
+
   $scope.shouldShowBuyCta = cta.shouldShowBuyCta;
   $scope.setBuyCtaDismissed = cta.setBuyCtaDissmissed;
   $scope.shouldShowSecurityWarning = cta.shouldShowSecurityWarning;

--- a/assets/js/controllers/walletNavigation.controller.js
+++ b/assets/js/controllers/walletNavigation.controller.js
@@ -8,11 +8,6 @@ function WalletNavigationCtrl ($rootScope, $scope, Wallet, SecurityCenter, $stat
   $scope.security = SecurityCenter.security;
   $scope.userHasAccount = buyStatus.userHasAccount();
 
-  // TODO: remove me
-  buyStatus.shouldShowInviteForm().then((res) => {
-    console.log('Should show form?', res);
-  });
-
   $scope.shouldShowBuyCta = cta.shouldShowBuyCta;
   $scope.setBuyCtaDismissed = cta.setBuyCtaDissmissed;
   $scope.shouldShowSecurityWarning = cta.shouldShowSecurityWarning;
@@ -20,6 +15,15 @@ function WalletNavigationCtrl ($rootScope, $scope, Wallet, SecurityCenter, $stat
   $scope.getSecurityWarningMessage = cta.getSecurityWarningMessage;
 
   buyStatus.canBuy().then((res) => $scope.canBuy = res);
+  buyStatus.shouldShowInviteForm().then((res) => $scope.shouldShowInviteForm = res);
+
+  $scope.showInviteForm = () => {
+    $uibModal.open({
+      templateUrl: 'partials/buy-subscribe-modal.jade',
+      windowClass: 'bc-modal xs',
+      controller: 'SubscribeCtrl'
+    });
+  };
 
   $scope.numberOfActiveLegacyAddresses = () => {
     if (!Wallet.status.isLoggedIn) return null;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,6 +11,7 @@ module.exports = function (config) {
 
     files: [
       'node_modules/babel-polyfill/dist/polyfill.js',
+      'node_modules/jasmine-es6-promise-matchers/jasmine-es6-promise-matchers.js',
       'bower_components/angular/angular.js',
       'bower_components/angular-sanitize/angular-sanitize.js',
       'bower_components/angular-mocks/angular-mocks.js',

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "istanbul": "^1.0.0-alpha.2",
     "jade": "*",
     "jasmine-core": "2.4.*",
+    "jasmine-es6-promise-matchers": "2.0.*",
     "jstransformer-verbatim": "^1.0.0",
     "karma": "0.13.*",
     "karma-babel-preprocessor": "6.0.*",

--- a/rootApp/Resources/wallet-options-debug.json
+++ b/rootApp/Resources/wallet-options-debug.json
@@ -10,7 +10,8 @@
                   ]
     },
     "sfox": {
-      "countries": ["US"]
+      "countries": ["US"],
+      "inviteFormFraction": 0.1
     }
   }
 }

--- a/tests/_prepare_spec.js.coffee
+++ b/tests/_prepare_spec.js.coffee
@@ -1,0 +1,1 @@
+JasminePromiseMatchers.install()

--- a/tests/services/buy_status_service_spec.coffee
+++ b/tests/services/buy_status_service_spec.coffee
@@ -1,7 +1,12 @@
 describe "buyStatus service", () ->
   Wallet = undefined
   MyWallet = undefined
+  MyWalletHelpers = undefined
   Options = undefined
+  accountInfo = undefined
+  buyStatus = undefined
+  $rootScope = undefined
+  sfoxOptions = undefined
 
   beforeEach angular.mock.module("walletApp")
 
@@ -11,21 +16,117 @@ describe "buyStatus service", () ->
       $q = _$q_
       Wallet = $injector.get("Wallet")
       MyWallet = $injector.get("MyWallet")
+      MyWalletHelpers = $injector.get("MyWalletHelpers")
       Options = $injector.get("Options")
+
+      accountInfo = {
+        countryCodeGuess: 'US',
+        invited: {
+          coinify: false,
+          sfox: false
+        }
+      }
+
+      sfoxOptions = {
+        countries: ['US']
+      }
+
+      MyWalletHelpers.isEmailInvited = (email, fraction) ->
+        if email == 'a@b.com'
+          return fraction >= 0.98046875
+        else if email == 'a+16@b.com'
+          return fraction >= 0.0078125
+        else
+          throw 'Mock does not know sha256 hash of ' + email
 
       Options.get = () ->
         Promise.resolve({
-          "showBuySellTab": ["US"],
-          "partners": {
-            "coinify": {
-              "countries": ["US"]
-            }
+          showBuySellTab: ["US"],
+          partners: {
+            coinify: {
+              countries: ["NL"]
+            },
+            sfox: sfoxOptions,
           }
         })
 
       MyWallet.wallet =
-        accountInfo:
-          countryCodeGuess: {}
+        accountInfo: accountInfo
         hdwallet:
           accounts: [{label: ""}, {label: "2nd account"}]
           defaultAccount: {index: 0}
+
+
+      buyStatus = $injector.get('buyStatus')
+
+  describe 'canBuy', ->
+    it 'should be false in a non-coinify country by default', (done) ->
+      expect(buyStatus.canBuy()).toBeResolvedWith(false, done)
+
+    # Coinify has been rolled out to 100%. Invite functionality will be pruned
+    # from backend, so e.g. get-info's 'invited' will no longer have a coinify flag.
+    # JSON web token will always be signed.
+    describe 'in a Coinify country', ->
+      beforeEach ->
+        accountInfo.countryCodeGuess = 'NL';
+
+      it 'should be true regardless of what backend says', (done) ->
+        accountInfo.countryCodeGuess = 'NL';
+        accountInfo.invited.coinify = false;
+        accountInfo.invited.sfox = false;
+
+        expect(buyStatus.canBuy()).toBeResolvedWith(true, done)
+
+    describe 'in an SFOX country', ->
+      beforeEach ->
+        accountInfo.countryCodeGuess = 'US';
+
+      it 'should be false when user is not invited', (done) ->
+        expect(buyStatus.canBuy()).toBeResolvedWith(false, done)
+
+      it 'should be true when user is invited', (done) ->
+        accountInfo.invited.sfox = true
+        expect(buyStatus.canBuy()).toBeResolvedWith(true, done)
+
+      it 'should not be affected by coinify.invited', (done) ->
+        accountInfo.invited.coinify = true # This needs to be ignored, otherwise
+                                           # we'd show the tab to everyone in the US
+        accountInfo.invited.sfox = false
+
+        expect(buyStatus.canBuy()).toBeResolvedWith(false, done)
+
+  describe 'showInviteForm()', ->
+    it 'should not show if canBuy() is true', (done) ->
+      spyOn(buyStatus, 'canBuy').and.callFake(() -> Promise.resolve(true))
+      expect(buyStatus.shouldShowInviteForm()).toBeResolvedWith(false, done)
+
+    it 'canBuy should return false for these tests', (done) ->
+      expect(buyStatus.canBuy()).toBeResolvedWith(false, done)
+
+    it 'should not show for non-SFOX countries', (done) ->
+      expect(buyStatus.shouldShowInviteForm()).toBeResolvedWith(false, done)
+
+    describe 'in SFOX countries', ->
+      beforeEach ->
+        accountInfo.countryCodeGuess = 'US';
+
+      it 'should not show if inviteFormFraction field is missing in wallet-options', (done) ->
+        expect(buyStatus.shouldShowInviteForm()).toBeResolvedWith(false, done)
+
+      it 'should be shown to fraction of emails based on sha256 hash', (done) ->
+        sfoxOptions.inviteFormFraction = 0.01 # 1%
+
+        accountInfo.email = "a+16@b.com" # requires > 0.0078% threshold
+        expect(buyStatus.shouldShowInviteForm()).toBeResolvedWith(true, done)
+
+      it 'should not show for non-SFOX countries, even if hash matches', (done) ->
+        accountInfo.countryCodeGuess = 'NL';
+        sfoxOptions.inviteFormFraction = 0.01 # 1%
+
+        accountInfo.email = "a+16@b.com" # requires > 0.0078% threshold
+
+        expect(buyStatus.shouldShowInviteForm()).toBeResolvedWith(false, done)
+
+      it 'should not be shown to remaining fraction of emails', (done) ->
+        accountInfo.email = "a@b.com" # requires >98% threshold
+        expect(buyStatus.shouldShowInviteForm()).toBeResolvedWith(false, done)


### PR DESCRIPTION
- [x] `buyStatus.shouldShowInviteForm()`
- [x] actually show form 
  - [x] show tab if `canBuy || shouldShowInviteForm`
  - [x] show form if `shouldShowInviteForm`
- [x] SFOX should not appear in the dropdown if the user is outside the US (temporary)