### PR TITLE
Disable trading when trade is pending

### DIFF
--- a/app/partials/buy-sell.jade
+++ b/app/partials/buy-sell.jade
@@ -8,12 +8,16 @@
   div(ng-if="!status.loading && !status.metaDataDown && !status.exchangeDown || status.disabled")
     .flex-row.flex-column-tablet
       .width-50.mrl.mtl(ng-show="state.buy")
-        buy-quick-start(transaction="transaction"
+        buy-quick-start(limits="limits"
+                        transaction="transaction"
+                        disabled="status.disabled"
                         currency-symbol="currencySymbol"
                         modal-open="status.modalOpen"
                         change-currency="changeCurrency(currency)"
-                        limits="limits"
                         trading-disabled="getIsTradingDisabled()"
+                        is-pending-trade="getIsPurchasePending()"
+                        open-pending-trade="buy(pendingTrade)"
+                        pending-trade="pendingTrade"
                         buy="buy(null, {quote: quote, btc: btc, fiat: fiat, currency: transaction.currency})")
       .flex-column.width-50.mlvl.mt-55
         div(ng-hide="trades.pending.length || trades.completed.length || (kyc && kyc.state !== 'completed')")

--- a/app/templates/buy-quick-start.jade
+++ b/app/templates/buy-quick-start.jade
@@ -9,7 +9,7 @@
         div(ng-show="exchangeRate.fiat")
           span.type-sm.em-500 1 BTC = {{currencySymbol.symbol}}{{ exchangeRate.fiat }}
           helper-button(content="EXCHANGE_RATE_HELPER")
-      fieldset(ng-disabled="tradingDisabled")
+      fieldset(ng-disabled="tradingDisabled || isPendingTrade")
         .flex-row.flex-between.flex-center.flex-column-tablet
           section.input-group.width-45
             input.form-control.brdrn(
@@ -53,7 +53,7 @@
               required)
             div.input-group-btn
               button.btn.btn-default.brdrn.disabled BTC
-        .mts.pos-rel(ng-hide="tradingDisabled")
+        .mts.pos-rel(ng-hide="tradingDisabled || isPendingTrade")
           span.pos-abs.type-sm.state-danger-text(ng-show="fiatForm.fiat.$error.min" translate="BUY_AMT_LOW")
           span.pos-abs.type-sm.state-danger-text(ng-show="fiatForm.fiat.$error.max" translate="BUY_AMT_HIGH")
         .mts.pos-rel(ng-show="tradingDisabled")
@@ -61,10 +61,22 @@
             span.state-danger-text(translate="BUY_AMT_IS" translate-values="{symbol: currencySymbol.symbol, amount: 0}")
             span  
             span.blue.pointer(ng-click="openVerificationNeeded()" translate="WHY")
+        .mts.pos-rel(ng-show="isPendingTrade")
+          span.pos-abs.type-sm
+            span.blue.pointer(ng-click="openPendingTrade()" translate="FINISH")
+            | 
+            span(translate="OR")
+            | 
+            span.blue.pointer(ng-click="cancelTrade()" translate="CANCEL")
+            | 
+            span(translate="PURCHASE_PENDING")
+            | 
+            span ${{ format(pendingTrade.sendAmount / 100, pendingTrade.inCurrency, false) }}
+            | .
       .flex-end.mtvl.pos-rel
         span.coinify-logo.coinify-logo-left
           span.mrs.type-sm(translate="POWERED_BY")
           a(href="https://www.coinify.com/" target="_blank" rel="noopener noreferrer")
             img(src="img/coinify-logo.svg")
             span.pos-abs.fade.height-100.width-100(uib-tooltip="{{'PROCESSED_BY_EXCHANGE' | translate}}" tooltip-append-to-body="true")
-        button.button-primary(translate="Buy Bitcoin" type="submit" ng-disabled="!fiatForm.$valid || status.busy || tradingDisabled")
+        button.button-primary(translate="Buy Bitcoin" type="submit" ng-disabled="!fiatForm.$valid || status.busy || tradingDisabled || isPendingTrade")

--- a/app/templates/buy-quick-start.jade
+++ b/app/templates/buy-quick-start.jade
@@ -61,7 +61,7 @@
             span.state-danger-text(translate="BUY_AMT_IS" translate-values="{symbol: currencySymbol.symbol, amount: 0}")
             span  
             span.blue.pointer(ng-click="openVerificationNeeded()" translate="WHY")
-        .mts.pos-rel(ng-show="isPendingTrade")
+        .mts.pos-rel(ng-show="isPendingTrade && canCancelTrade")
           span.pos-abs.type-sm
             span.blue.pointer(ng-click="openPendingTrade()" translate="FINISH")
             | 
@@ -71,8 +71,11 @@
             | 
             span(translate="PURCHASE_PENDING")
             | 
-            span ${{ format(pendingTrade.sendAmount / 100, pendingTrade.inCurrency, false) }}
+            span {{ format(pendingTrade.sendAmount, {code: pendingTrade.inCurrency}, true) }}
             | .
+        .mts.pos-rel(ng-show="isPendingTrade && !canCancelTrade")
+          span.pos-abs.type-sm
+            span.blue.pointer(ng-click="openPendingTrade()" translate="PURCHASE_PENDING_CANT_CANCEL")
       .flex-end.mtvl.pos-rel
         span.coinify-logo.coinify-logo-left
           span.mrs.type-sm(translate="POWERED_BY")

--- a/app/templates/buy-quick-start.jade
+++ b/app/templates/buy-quick-start.jade
@@ -71,7 +71,7 @@
             | 
             span(translate="PURCHASE_PENDING")
             | 
-            span {{ format(pendingTrade.sendAmount, {code: pendingTrade.inCurrency}, true) }}
+            span {{ format(pendingTrade.sendAmount / 100, {code: pendingTrade.inCurrency}, true) }}
             | .
         .mts.pos-rel(ng-show="isPendingTrade && !canCancelTrade")
           span.pos-abs.type-sm

--- a/assets/js/controllers/buySell.controller.js
+++ b/assets/js/controllers/buySell.controller.js
@@ -130,11 +130,10 @@ function BuySellCtrl ($rootScope, $scope, $state, Alerts, Wallet, currency, buyS
     let trades = $scope.exchange && $scope.exchange.trades.sort((a, b) => b.id - a.id);
     let completedTrades = trades && trades.filter(buySell.tradeStateIn(buySell.states.success));
     let purchasePending = trades && trades[0] && buySell.tradeStateIn(buySell.states.pending)(trades[0]);
-    let isMediumCard = trades && trades[0] && trades[0].medium === 'card';
 
     $scope.pendingTrade = purchasePending ? trades[0] : undefined;
 
-    return purchasePending && isMediumCard && completedTrades.length === 0;
+    return purchasePending && completedTrades.length === 0;
   };
 
   $scope.getIsTradingDisabled = () => {

--- a/assets/js/controllers/buySell.controller.js
+++ b/assets/js/controllers/buySell.controller.js
@@ -126,9 +126,20 @@ function BuySellCtrl ($rootScope, $scope, $state, Alerts, Wallet, currency, buyS
     buySell.getRate($scope.exchange.profile.defaultCurrency, $scope.transaction.currency.code).then(calculateMax);
   };
 
+  $scope.getIsPurchasePending = () => {
+    let trades = $scope.exchange && $scope.exchange.trades.sort((a, b) => b.id - a.id);
+    let completedTrades = trades && trades.filter(buySell.tradeStateIn(buySell.states.success));
+    let purchasePending = trades && trades[0] && buySell.tradeStateIn(buySell.states.pending)(trades[0]);
+
+    $scope.pendingTrade = purchasePending ? trades[0] : undefined;
+
+    return purchasePending === true && completedTrades.length === 0;
+  };
+
   $scope.getIsTradingDisabled = () => {
     let profile = $scope.exchange && $scope.exchange.profile;
     let canTrade = profile && profile.canTrade;
+
     return canTrade === false;
   };
 

--- a/assets/js/controllers/buySell.controller.js
+++ b/assets/js/controllers/buySell.controller.js
@@ -131,7 +131,7 @@ function BuySellCtrl ($rootScope, $scope, $state, Alerts, Wallet, currency, buyS
     let completedTrades = trades && trades.filter(buySell.tradeStateIn(buySell.states.success));
     let purchasePending = trades && trades[0] && buySell.tradeStateIn(buySell.states.pending)(trades[0]);
 
-    $scope.pendingTrade = purchasePending ? trades[0] : undefined;
+    if (purchasePending) $scope.pendingTrade = trades[0];
 
     return purchasePending && completedTrades.length === 0;
   };

--- a/assets/js/controllers/buySell.controller.js
+++ b/assets/js/controllers/buySell.controller.js
@@ -139,6 +139,12 @@ function BuySellCtrl ($rootScope, $scope, $state, Alerts, Wallet, currency, buyS
   $scope.getIsTradingDisabled = () => {
     let profile = $scope.exchange && $scope.exchange.profile;
     let canTrade = profile && profile.canTrade;
+    let cannotTradeReason = profile && profile.cannotTradeReason;
+
+    // Coinify is not setting canTrade to false when purchase is pending.
+    // If that bug is fixed after we deploy this returns false and uses
+    // getIsPurchasePending logic above.
+    if (cannotTradeReason === 'awaiting_first_trade_completion') return false;
 
     return canTrade === false;
   };

--- a/assets/js/controllers/buySell.controller.js
+++ b/assets/js/controllers/buySell.controller.js
@@ -130,10 +130,11 @@ function BuySellCtrl ($rootScope, $scope, $state, Alerts, Wallet, currency, buyS
     let trades = $scope.exchange && $scope.exchange.trades.sort((a, b) => b.id - a.id);
     let completedTrades = trades && trades.filter(buySell.tradeStateIn(buySell.states.success));
     let purchasePending = trades && trades[0] && buySell.tradeStateIn(buySell.states.pending)(trades[0]);
+    let isMediumCard = trades && trades[0] && trades[0].medium === 'card';
 
     $scope.pendingTrade = purchasePending ? trades[0] : undefined;
 
-    return purchasePending === true && completedTrades.length === 0;
+    return purchasePending && isMediumCard && completedTrades.length === 0;
   };
 
   $scope.getIsTradingDisabled = () => {

--- a/assets/js/directives/buy-quick-start.directive.js
+++ b/assets/js/directives/buy-quick-start.directive.js
@@ -104,6 +104,8 @@ function buyQuickStart (currency, buySell, Alerts, $interval, $timeout, modals) 
       modals.openTemplate('partials/verification-needed-modal.jade', { days }, options);
     };
 
+    scope.canCancelTrade = scope.pendingTrade && scope.pendingTrade.state === 'awaiting_transfer_in';
+
     scope.getExchangeRate();
     scope.$on('$destroy', stopFetchingQuote);
     scope.$watch('modalOpen', (modalOpen) => {

--- a/assets/js/directives/buy-quick-start.directive.js
+++ b/assets/js/directives/buy-quick-start.directive.js
@@ -104,12 +104,13 @@ function buyQuickStart (currency, buySell, Alerts, $interval, $timeout, modals) 
       modals.openTemplate('partials/verification-needed-modal.jade', { days }, options);
     };
 
-    scope.canCancelTrade = scope.pendingTrade && scope.pendingTrade.state === 'awaiting_transfer_in';
-
     scope.getExchangeRate();
     scope.$on('$destroy', stopFetchingQuote);
     scope.$watch('modalOpen', (modalOpen) => {
       modalOpen ? stopFetchingQuote() : scope.getExchangeRate();
+    });
+    scope.$watch('pendingTrade.state', (state) => {
+      scope.canCancelTrade = state === 'awaiting_transfer_in';
     });
   }
 }

--- a/assets/js/directives/buy-quick-start.directive.js
+++ b/assets/js/directives/buy-quick-start.directive.js
@@ -12,7 +12,11 @@ function buyQuickStart (currency, buySell, Alerts, $interval, $timeout, modals) 
     scope: {
       buy: '&',
       limits: '=',
+      disabled: '=',
       tradingDisabled: '=',
+      isPendingTrade: '=',
+      openPendingTrade: '&',
+      pendingTrade: '=',
       modalOpen: '=',
       transaction: '=',
       currencySymbol: '=',
@@ -27,6 +31,7 @@ function buyQuickStart (currency, buySell, Alerts, $interval, $timeout, modals) 
     scope.exchangeRate = {};
     scope.status = {ready: true};
     scope.currencies = currency.coinifyCurrencies;
+    scope.format = currency.formatCurrencyForView;
 
     scope.updateLastInput = (type) => scope.lastInput = type;
 
@@ -79,6 +84,16 @@ function buyQuickStart (currency, buySell, Alerts, $interval, $timeout, modals) 
     const error = () => {
       scope.status = {};
       Alerts.displayError('ERROR_QUOTE_FETCH');
+    };
+
+    scope.cancelTrade = () => {
+      scope.disabled = true;
+      Alerts.confirm('CONFIRM_CANCEL_TRADE', {
+        action: 'CANCEL_TRADE',
+        cancel: 'GO_BACK'
+      }).then(() => scope.pendingTrade.cancel(), () => {})
+        .catch((e) => { Alerts.displayError('ERROR_TRADE_CANCEL'); })
+        .finally(() => scope.disabled = false);
     };
 
     scope.openVerificationNeeded = () => {

--- a/assets/js/directives/trade.directive.js
+++ b/assets/js/directives/trade.directive.js
@@ -72,7 +72,7 @@ function trade ($rootScope, Alerts, MyWallet, $timeout, $interval, buySell) {
       if (newVal) scope.updateBTCExpected();
       else scope.status = {};
     });
-    scope.$watch('status.canceling', () => {
+    scope.$watchGroup(['status.canceling', 'trade.state'], () => {
       scope.canCancel =
         !scope.status.canceling &&
         scope.trade.state === 'awaiting_transfer_in' &&

--- a/locales/en-human.json
+++ b/locales/en-human.json
@@ -1204,5 +1204,6 @@
   "VERIFICATION_NEEDED": "Verification Needed",
   "VERIFICATION_NEEDED_EXPLAIN": "Please bear with us as our exchange partner verifies your credit card information. This will only happen once, and you may resume purchasing bitcoin in <b>{{days}} day(s).</b>",
   "PURCHASE_PENDING": "your pending purchase for",
+  "PURCHASE_PENDING_CANT_CANCEL": "Please wait for your pending trade to complete.",
   "": ""
 }

--- a/locales/en-human.json
+++ b/locales/en-human.json
@@ -1203,5 +1203,6 @@
   "unable to verify identity": "We were unable to verify your identity. Please try again.",
   "VERIFICATION_NEEDED": "Verification Needed",
   "VERIFICATION_NEEDED_EXPLAIN": "Please bear with us as our exchange partner verifies your credit card information. This will only happen once, and you may resume purchasing bitcoin in <b>{{days}} day(s).</b>",
+  "PURCHASE_PENDING": "your pending purchase for",
   "": ""
 }


### PR DESCRIPTION
This can be used as a fallback to prevent !canTrade errors later in the flow.