### PR TITLE
Use canTrade flag for disabling trades

### DIFF
--- a/app/partials/buy-sell.jade
+++ b/app/partials/buy-sell.jade
@@ -15,7 +15,7 @@
                         modal-open="status.modalOpen"
                         change-currency="changeCurrency(currency)"
                         trading-disabled="getIsTradingDisabled()"
-                        is-pending-trade="getIsPurchasePending()"
+                        trading-disabled-reason="getIsTradingDisabledReason()"
                         open-pending-trade="buy(pendingTrade)"
                         pending-trade="pendingTrade"
                         buy="buy(null, {quote: quote, btc: btc, fiat: fiat, currency: transaction.currency})")

--- a/app/templates/buy-quick-start.jade
+++ b/app/templates/buy-quick-start.jade
@@ -9,7 +9,7 @@
         div(ng-show="exchangeRate.fiat")
           span.type-sm.em-500 1 BTC = {{currencySymbol.symbol}}{{ exchangeRate.fiat }}
           helper-button(content="EXCHANGE_RATE_HELPER")
-      fieldset(ng-disabled="tradingDisabled || isPendingTrade")
+      fieldset(ng-disabled="tradingDisabled")
         .flex-row.flex-between.flex-center.flex-column-tablet
           section.input-group.width-45
             input.form-control.brdrn(
@@ -53,15 +53,15 @@
               required)
             div.input-group-btn
               button.btn.btn-default.brdrn.disabled BTC
-        .mts.pos-rel(ng-hide="tradingDisabled || isPendingTrade")
+        .mts.pos-rel(ng-hide="tradingDisabled")
           span.pos-abs.type-sm.state-danger-text(ng-show="fiatForm.fiat.$error.min" translate="BUY_AMT_LOW")
           span.pos-abs.type-sm.state-danger-text(ng-show="fiatForm.fiat.$error.max" translate="BUY_AMT_HIGH")
-        .mts.pos-rel(ng-show="tradingDisabled")
+        .mts.pos-rel(ng-show="tradingDisabled && tradingDisabledReason === 'after_first_trade'")
           span.pos-abs.type-sm
             span.state-danger-text(translate="BUY_AMT_IS" translate-values="{symbol: currencySymbol.symbol, amount: 0}")
             span  
             span.blue.pointer(ng-click="openVerificationNeeded()" translate="WHY")
-        .mts.pos-rel(ng-show="isPendingTrade && canCancelTrade")
+        .mts.pos-rel(ng-show="tradingDisabled && tradingDisabledReason === 'awaiting_first_trade_completion'")
           span.pos-abs.type-sm
             span.blue.pointer(ng-click="openPendingTrade()" translate="FINISH")
             | 
@@ -73,13 +73,10 @@
             | 
             span {{ format(pendingTrade.sendAmount / 100, {code: pendingTrade.inCurrency}, true) }}
             | .
-        .mts.pos-rel(ng-show="isPendingTrade && !canCancelTrade")
-          span.pos-abs.type-sm
-            span.blue.pointer(ng-click="openPendingTrade()" translate="PURCHASE_PENDING_CANT_CANCEL")
       .flex-end.mtvl.pos-rel
         span.coinify-logo.coinify-logo-left
           span.mrs.type-sm(translate="POWERED_BY")
           a(href="https://www.coinify.com/" target="_blank" rel="noopener noreferrer")
             img(src="img/coinify-logo.svg")
             span.pos-abs.fade.height-100.width-100(uib-tooltip="{{'PROCESSED_BY_EXCHANGE' | translate}}" tooltip-append-to-body="true")
-        button.button-primary(translate="Buy Bitcoin" type="submit" ng-disabled="!fiatForm.$valid || status.busy || tradingDisabled || isPendingTrade")
+        button.button-primary(translate="Buy Bitcoin" type="submit" ng-disabled="!fiatForm.$valid || status.busy || tradingDisabled")

--- a/assets/js/controllers/buySell.controller.js
+++ b/assets/js/controllers/buySell.controller.js
@@ -61,6 +61,10 @@ function BuySellCtrl ($rootScope, $scope, $state, Alerts, Wallet, currency, buyS
         $scope.status.disabled = false;
         $scope.getMaxMin();
 
+        let pending = buySell.trades.pending;
+        let pendingUserAction = pending.filter((t) => t.state === 'awaiting_transfer_in');
+        $scope.pendingTrade = pendingUserAction.sort((a, b) => b.id - a.id)[0];
+
         if ($scope.exchange) {
           if (+$scope.exchange.profile.level.name < 2) {
             if ($scope.kyc) {
@@ -126,27 +130,18 @@ function BuySellCtrl ($rootScope, $scope, $state, Alerts, Wallet, currency, buyS
     buySell.getRate($scope.exchange.profile.defaultCurrency, $scope.transaction.currency.code).then(calculateMax);
   };
 
-  $scope.getIsPurchasePending = () => {
-    let trades = $scope.exchange && $scope.exchange.trades.sort((a, b) => b.id - a.id);
-    let completedTrades = trades && trades.filter(buySell.tradeStateIn(buySell.states.success));
-    let purchasePending = trades && trades[0] && buySell.tradeStateIn(buySell.states.pending)(trades[0]);
-
-    if (purchasePending) $scope.pendingTrade = trades[0];
-
-    return purchasePending && completedTrades.length === 0;
-  };
-
   $scope.getIsTradingDisabled = () => {
     let profile = $scope.exchange && $scope.exchange.profile;
     let canTrade = profile && profile.canTrade;
-    let cannotTradeReason = profile && profile.cannotTradeReason;
-
-    // Coinify is not setting canTrade to false when purchase is pending.
-    // If that bug is fixed after we deploy this returns false and uses
-    // getIsPurchasePending logic above.
-    if (cannotTradeReason === 'awaiting_first_trade_completion') return false;
 
     return canTrade === false;
+  };
+
+  $scope.getIsTradingDisabledReason = () => {
+    let profile = $scope.exchange && $scope.exchange.profile;
+    let cannotTradeReason = profile && profile.cannotTradeReason;
+
+    return cannotTradeReason;
   };
 
   $rootScope.$on('fetchExchangeProfile', () => {

--- a/assets/js/directives/buy-quick-start.directive.js
+++ b/assets/js/directives/buy-quick-start.directive.js
@@ -3,9 +3,9 @@ angular.module('walletApp')
 
 const ONE_DAY_MS = 86400000;
 
-buyQuickStart.$inject = ['currency', 'buySell', 'Alerts', '$interval', '$timeout', 'modals'];
+buyQuickStart.$inject = ['$rootScope', 'currency', 'buySell', 'Alerts', '$interval', '$timeout', 'modals'];
 
-function buyQuickStart (currency, buySell, Alerts, $interval, $timeout, modals) {
+function buyQuickStart ($rootScope, currency, buySell, Alerts, $interval, $timeout, modals) {
   const directive = {
     restrict: 'E',
     replace: true,
@@ -14,7 +14,7 @@ function buyQuickStart (currency, buySell, Alerts, $interval, $timeout, modals) 
       limits: '=',
       disabled: '=',
       tradingDisabled: '=',
-      isPendingTrade: '=',
+      tradingDisabledReason: '=',
       openPendingTrade: '&',
       pendingTrade: '=',
       modalOpen: '=',
@@ -91,7 +91,7 @@ function buyQuickStart (currency, buySell, Alerts, $interval, $timeout, modals) 
       Alerts.confirm('CONFIRM_CANCEL_TRADE', {
         action: 'CANCEL_TRADE',
         cancel: 'GO_BACK'
-      }).then(() => scope.pendingTrade.cancel(), () => {})
+      }).then(() => scope.pendingTrade.cancel().then(() => buySell.fetchProfile()), () => {})
         .catch((e) => { Alerts.displayError('ERROR_TRADE_CANCEL'); })
         .finally(() => scope.disabled = false);
     };
@@ -108,9 +108,6 @@ function buyQuickStart (currency, buySell, Alerts, $interval, $timeout, modals) 
     scope.$on('$destroy', stopFetchingQuote);
     scope.$watch('modalOpen', (modalOpen) => {
       modalOpen ? stopFetchingQuote() : scope.getExchangeRate();
-    });
-    scope.$watch('pendingTrade.state', (state) => {
-      scope.canCancelTrade = state === 'awaiting_transfer_in';
     });
   }
 }


### PR DESCRIPTION
If canTrade is set properly after first purchase is initiated, use this branch.

Depends on Coinify bug fix.