### PR TITLE
Only allow one trade summary modal at a time

### DIFF
--- a/assets/js/controllers/sfox/sfoxCheckout.controller.js
+++ b/assets/js/controllers/sfox/sfoxCheckout.controller.js
@@ -49,8 +49,8 @@ function SfoxCheckoutController ($scope, $timeout, $stateParams, $q, Wallet, MyW
         $scope.siftScienceEnabled = true;
         $scope.tradeId = trade.id;
         $scope.selectTab('ORDER_HISTORY');
-        let modalInstance = modals.openTradeSummary(trade, 'initiated');
-        sfox.watchTrade(trade, () => modalInstance.dismiss());
+        modals.openTradeSummary(trade, 'initiated');
+        sfox.watchTrade(trade);
       })
       .catch(() => {
         Alerts.displayError('Error connecting to our exchange partner');

--- a/assets/js/services/modals.service.js
+++ b/assets/js/services/modals.service.js
@@ -18,6 +18,14 @@ function modals ($state, $uibModal, $ocLazyLoad) {
     };
   };
 
+  service.dismissPrevious = (modalOpener) => {
+    let modalInstance = null;
+    return (...args) => {
+      if (modalInstance) modalInstance.dismiss('overridden');
+      modalInstance = modalOpener(...args);
+    };
+  };
+
   service.openBankHelper = () => open({
     templateUrl: 'partials/bank-check-modal.jade',
     windowClass: 'bc-modal medium'
@@ -66,7 +74,7 @@ function modals ($state, $uibModal, $ocLazyLoad) {
     if (goingToBuySellState) $state.go('wallet.common.buy-sell');
   });
 
-  service.openTradeSummary = (trade, state) => open({
+  service.openTradeSummary = service.dismissPrevious((trade, state) => open({
     templateUrl: 'partials/trade-modal.jade',
     windowClass: 'bc-modal trade-summary',
     controller ($scope, trade, formatTrade, accounts) {
@@ -81,7 +89,7 @@ function modals ($state, $uibModal, $ocLazyLoad) {
           : $q.resolve([]);
       }
     }
-  });
+  }));
 
   return service;
 }

--- a/assets/js/services/sfox.service.js
+++ b/assets/js/services/sfox.service.js
@@ -80,11 +80,10 @@ function sfox ($q, Alerts, modals) {
       .forEach(service.watchTrade);
   }
 
-  function watchTrade (trade, completedCallback) {
+  function watchTrade (trade) {
     watching[trade.receiveAddress] = true;
     $q.resolve(trade.watchAddress())
       .then(() => trade.refresh())
-      .then(() => { modals.openTradeSummary(trade, 'success'); })
-      .then(completedCallback);
+      .then(() => { modals.openTradeSummary(trade, 'success'); });
   }
 }

--- a/tests/controllers/sfox/sfox_checkout_ctrl.coffee
+++ b/tests/controllers/sfox/sfox_checkout_ctrl.coffee
@@ -84,16 +84,6 @@ describe "SfoxCheckoutController", ->
     beforeEach ->
       scope = getControllerScope([{status:'active'}])
 
-    it "should watch the trade for completion and close the first modal", ->
-      dismissSpy = jasmine.createSpy("dismiss")
-      spyOn(modals, "openTradeSummary").and.returnValue(dismiss: dismissSpy)
-      spyOn(sfox, "watchTrade").and.callFake((trade, cb) -> cb())
-      scope.buyHandler(mockQuote())
-      scope.$digest()
-      trade = jasmine.objectContaining({ id: "TRADE" })
-      expect(sfox.watchTrade).toHaveBeenCalledWith(trade, jasmine.any(Function))
-      expect(dismissSpy).toHaveBeenCalled()
-
     it "should open the trade summary modal", ->
       spyOn(modals, "openTradeSummary").and.callThrough()
       scope.buyHandler(mockQuote())


### PR DESCRIPTION
Wasn't able to use `openOnce`, which prevents more modals from opening. Instead I added `dismissPrevious`, which will close the last modal before opening a new one.