### PR TITLE
Remove main password restriction

### DIFF
--- a/assets/js/controllers/settings/info.controller.js
+++ b/assets/js/controllers/settings/info.controller.js
@@ -26,12 +26,10 @@ function SettingsInfoCtrl ($scope, $q, Wallet, Alerts) {
 
     let error = (err) => {
       if (err === 'cancelled' || err === 'backdrop click') return;
-      let msg = err === 'incorrect_main_pw' ? 'INCORRECT_PASSWORD' : 'SHOW_PAIRING_CODE_FAIL';
-      Alerts.displayError(msg);
+      Alerts.displayError('SHOW_PAIRING_CODE_FAIL');
     };
 
-    Wallet.askForMainPasswordConfirmation()
-      .then(() => $q(Wallet.makePairingCode))
+    $q(Wallet.makePairingCode)
       .then(success, error)
       .then(() => $scope.loading.code = false);
   };

--- a/assets/js/directives/confirm-recovery-phrase.directive.js
+++ b/assets/js/directives/confirm-recovery-phrase.directive.js
@@ -18,23 +18,11 @@ function confirmRecoveryPhrase ($uibModal, Wallet, Alerts) {
   return directive;
 
   function link (scope, elem, attrs) {
-    let openModal = () => $uibModal.open({
+    scope.confirmRecoveryPhrase = () => $uibModal.open({
       templateUrl: 'partials/confirm-recovery-phrase-modal.pug',
       controller: 'ConfirmRecoveryPhraseCtrl',
       windowClass: 'bc-modal'
     });
-
-    scope.confirmRecoveryPhrase = () => (
-      Wallet.settings.secondPassword
-        ? openModal()
-        : Wallet.askForMainPasswordConfirmation()
-          .then(openModal)
-          .catch((reason) => {
-            if (reason !== 'incorrect_main_pw') return;
-            Alerts.displayError('INCORRECT_PASSWORD');
-            scope.confirmRecoveryPhrase();
-          })
-      );
 
     if (scope.promptBackup) scope.confirmRecoveryPhrase();
   }

--- a/assets/js/services/wallet.service.js
+++ b/assets/js/services/wallet.service.js
@@ -397,12 +397,6 @@ function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWalle
     return defer.promise;
   };
 
-  wallet.askForMainPasswordConfirmation = () => (
-    Alerts.prompt('MAIN_PW_REQUIRED', { type: 'password' })
-      .then(wallet.isCorrectMainPassword)
-      .then(correct => correct ? $q.resolve(true) : $q.reject('incorrect_main_pw'))
-  );
-
   wallet.saveActivity = () => {
     // TYPES: ['transactions', 'security', 'settings', 'accounts']
     $rootScope.$broadcast('updateActivityFeed');

--- a/tests/controllers/settings_info_ctrl_spec.coffee
+++ b/tests/controllers/settings_info_ctrl_spec.coffee
@@ -16,8 +16,6 @@ describe "SettingsInfoCtrl", ->
       Wallet.user.alias = "user_alias"
       Wallet.makePairingCode = (success, error) ->
         if scope.pairingCode then error() else success("code")
-      Wallet.askForMainPasswordConfirmation = () ->
-        if scope._enterIncorrectPw then $q.reject('incorrect_main_pw') else $q.resolve(true)
       Wallet.removeAlias = () -> $q.resolve()
 
       scope = $rootScope.$new()
@@ -54,14 +52,6 @@ describe "SettingsInfoCtrl", ->
       scope.showPairingCode()
       scope.$digest()
       expect(Alerts.displayError).toHaveBeenCalledWith('SHOW_PAIRING_CODE_FAIL')
-      expect(scope.loading.code).toEqual(false)
-
-    it "should not display the code if main pw was not entered", ->
-      spyOn(Alerts, "displayError")
-      scope._enterIncorrectPw = true
-      scope.showPairingCode()
-      scope.$digest()
-      expect(Alerts.displayError).toHaveBeenCalledWith('INCORRECT_PASSWORD')
       expect(scope.loading.code).toEqual(false)
 
     it "should hide", ->

--- a/tests/directives/confirm-recovery-phrase_spec.coffee
+++ b/tests/directives/confirm-recovery-phrase_spec.coffee
@@ -13,46 +13,18 @@ describe "Confirm Recovery Phrase", ->
     Wallet = $injector.get("Wallet")
     Alerts = $injector.get("Alerts")
 
+    spyOn(Alerts, "prompt").and.returnValue($q.resolve('asdf'))
+    spyOn($uibModal, "open").and.callThrough()
+
     element = $compile("<confirm-recovery-phrase></confirm-recovery-phrase>")($rootScope)
     $rootScope.$digest()
     isoScope = element.isolateScope()
     isoScope.$digest()
-
-    spyOn(Alerts, "prompt").and.returnValue($q.resolve('asdf'))
-    spyOn($uibModal, "open").and.callThrough()
   )
 
-  it "should open when second pw is enabled", ->
-    Wallet.settings.secondPassword = true
+  it "should open", ->
     isoScope.confirmRecoveryPhrase()
     expect($uibModal.open).toHaveBeenCalled()
-
-  it "should prompt for main password when second pw is not enabled", ->
-    isoScope.confirmRecoveryPhrase()
-    expect(Alerts.prompt).toHaveBeenCalled()
-
-  it "should validate the main password", ->
-    spyOn(Wallet, "isCorrectMainPassword").and.returnValue(true)
-
-    isoScope.confirmRecoveryPhrase()
-    expect(Alerts.prompt).toHaveBeenCalled()
-
-    isoScope.$digest()
-    expect($uibModal.open).toHaveBeenCalled()
-
-  it "should display an error and retry if the main password was incorrect", ->
-    spyOn(Alerts, "displayError").and.callThrough()
-    spyOn(Wallet, "isCorrectMainPassword").and.returnValue(false)
-
-    isoScope.confirmRecoveryPhrase()
-    spyOn(isoScope, "confirmRecoveryPhrase")
-
-    expect(Alerts.prompt).toHaveBeenCalled()
-    isoScope.$digest()
-
-    expect(Alerts.displayError).toHaveBeenCalled()
-    expect(isoScope.confirmRecoveryPhrase).toHaveBeenCalled()
 
   it "should not prompt backup recovery phrase modal if promptBackup is not set", ->
-    spyOn(isoScope, 'confirmRecoveryPhrase')
-    expect(isoScope.confirmRecoveryPhrase).not.toHaveBeenCalled()
+    expect($uibModal.open).not.toHaveBeenCalled()


### PR DESCRIPTION
For showing pairing code and viewing backup phrase. Removed because this feature is annoying and adds negligible security advantages.