### PR TITLE
Use last amount type for payment request

### DIFF
--- a/app/partials/request.pug
+++ b/app/partials/request.pug
@@ -33,26 +33,28 @@
               input.form-control.no-border(
                 type="number"
                 ng-model="state.amount"
-                name="amountFiat"
-                transform-currency="settings.currency"
+                name="amount"
+                transform-currency="settings.btcCurrency"
+                ng-change="state.amountType = 'amount'; state.baseCurr = settings.btcCurrency"
                 placeholder="0"
                 min="1"
                 max="2100000000000000"
                 required
                 autofocus)
-              span.mhm {{ settings.currency.code }}
+              span.mhm {{ settings.btcCurrency.code }}
             i.ti-arrows-horizontal.h4.basic-grey.phm
             .flex-1.flex-center.border
               input.form-control.no-border(
                 type="number"
                 ng-model="state.amount"
-                name="amount"
-                transform-currency="settings.btcCurrency"
+                name="amountFiat"
+                transform-currency="settings.currency"
+                ng-change="state.amountType = 'amount_local'; state.baseCurr = settings.currency"
                 placeholder="0"
                 min="1"
                 max="2100000000000000"
                 required)
-              span.mhm {{ settings.btcCurrency.code }}
+              span.mhm {{ settings.currency.code }}
       
       .group.mb-20(ng-show="numberOfActiveAccountsAndLegacyAddresses() > 1" ng-class="{'has-warning': state.to.isWatchOnly}")
         .item

--- a/assets/js/controllers/request.controller.js
+++ b/assets/js/controllers/request.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('RequestCtrl', RequestCtrl);
 
-function RequestCtrl ($rootScope, $scope, Wallet, Alerts, currency, $uibModalInstance, $log, destination, $translate, $stateParams, filterFilter, $filter, $q, format, smartAccount, Labels) {
+function RequestCtrl ($rootScope, $scope, Wallet, Alerts, currency, $uibModalInstance, $log, destination, $translate, $stateParams, filterFilter, $filter, $q, format, smartAccount, Labels, $timeout) {
   $scope.status = Wallet.status;
   $scope.settings = Wallet.settings;
   $scope.accounts = Wallet.accounts;
@@ -20,6 +20,7 @@ function RequestCtrl ($rootScope, $scope, Wallet, Alerts, currency, $uibModalIns
     label: '',
     amount: null,
     viewQR: null,
+    amountType: null,
     requestCreated: null
   };
 
@@ -75,7 +76,7 @@ function RequestCtrl ($rootScope, $scope, Wallet, Alerts, currency, $uibModalIns
   };
 
   $scope.paymentRequestURL = (isBitcoinURI) => {
-    let { amount, label } = $scope.state;
+    let { amount, label, amountType, baseCurr } = $scope.state;
     let { currency, btcCurrency } = $scope.settings;
     let url;
 
@@ -83,11 +84,21 @@ function RequestCtrl ($rootScope, $scope, Wallet, Alerts, currency, $uibModalIns
     else url = $rootScope.rootURL + 'payment_request?' + 'address=' + $scope.address() + '&';
 
     if (isBitcoinURI) url += amount ? 'amount=' + $scope.fromSatoshi(amount || 0, btcCurrency) + '&' : '';
-    else url += amount ? 'amount_local=' + $scope.fromSatoshi(amount || 0, currency) + '&' : '';
+    else url += amount ? amountType + '=' + $scope.fromSatoshi(amount || 0, baseCurr) + '&' : '';
+
+    if (!isBitcoinURI && amountType === 'amount_local') url += 'currency=' + currency.code + '&nosavecurrency=true&';
 
     url += label ? 'message=' + label + ' ' : '';
     return encodeURI(url.slice(0, -1));
   };
+
+  $scope.resetCopy = () => {
+    $scope.state.isAddressCopied = false;
+    $scope.state.isBitcoinURICopied = false;
+    $scope.state.isPaymentRequestCopied = false;
+  };
+
+  $scope.$watchGroup(['state.amount', 'state.label'], $scope.resetCopy);
 
   $scope.installLock();
 }

--- a/tests/controllers/request_ctrl_spec.coffee
+++ b/tests/controllers/request_ctrl_spec.coffee
@@ -112,49 +112,67 @@ describe "RequestCtrl", ->
       expect(foundAccount).toBe(true)
       expect(foundLegacyAddress).toBe(true)
 
-    describe "paymentRequestURL", ->
+  describe "paymentRequestURL", ->
 
-      it "should show a payment URL when legacy address is selected", ->
-        scope.state.to = scope.legacyAddresses()[0]
-        scope.$digest()
-        expect(scope.paymentRequestURL()).toBeDefined()
-        expect(scope.paymentRequestURL()).toContain("payment_request")
+    it "should use the latest currency", ->
+      scope.state.to = scope.legacyAddresses()[0]
+      scope.state.amountType = 'amount_local'
+      scope.state.baseCurr = scope.settings.currency
+      scope.state.amount = 10000000
+      
+      expect(scope.paymentRequestURL()).toContain("USD")
+    
+    it "should show a payment URL when legacy address is selected", ->
+      scope.state.to = scope.legacyAddresses()[0]
+      scope.$digest()
+      expect(scope.paymentRequestURL()).toBeDefined()
+      expect(scope.paymentRequestURL()).toContain("payment_request")
 
 
-      it "should show a payment URL with amount when legacy address is selected and amount > 0", ->
-        scope.state.to = scope.legacyAddresses()[0]
-        scope.state.amount = 10000000
-        scope.$digest()
-        expect(scope.paymentRequestURL()).toBeDefined()
-        expect(scope.paymentRequestURL()).toContain("amount_local")
+    it "should show a payment URL with amount when legacy address is selected and amount > 0", ->
+      scope.state.to = scope.legacyAddresses()[0]
+      scope.state.amountType = 'amount_local'
+      scope.state.amount = 10000000
+      scope.$digest()
+      expect(scope.paymentRequestURL()).toBeDefined()
+      expect(scope.paymentRequestURL()).toContain("amount_local")
 
-      it "should not have amount argument in URL if amount is zero, null or empty", ->
-        scope.state.to = scope.legacyAddresses()[0]
-        scope.state.amount = null
-        scope.$digest()
-        expect(scope.paymentRequestURL()).toBeDefined()
-        expect(scope.paymentRequestURL()).not.toContain("amount_local=")
+    it "should not have amount argument in URL if amount is zero, null or empty", ->
+      scope.state.to = scope.legacyAddresses()[0]
+      scope.state.amount = null
+      scope.$digest()
+      expect(scope.paymentRequestURL()).toBeDefined()
+      expect(scope.paymentRequestURL()).not.toContain("amount_local=")
 
-        scope.state.amount = null
-        scope.$digest()
-        expect(scope.paymentRequestURL()).not.toContain("amount_local=")
+      scope.state.amount = null
+      scope.$digest()
+      expect(scope.paymentRequestURL()).not.toContain("amount_local=")
 
-        scope.state.amount = ""
-        scope.$digest()
-        expect(scope.paymentRequestURL()).not.toContain("amount_local=")
+      scope.state.amount = ""
+      scope.$digest()
+      expect(scope.paymentRequestURL()).not.toContain("amount_local=")
 
-      it "should generate a valid payment request url", ->
-        scope.state.to = scope.legacyAddresses()[0]
-        scope.state.label = "Label Label Label"
-        scope.state.amount = null
-        scope.$digest()
+    it "should generate a valid payment request url", ->
+      scope.state.to = scope.legacyAddresses()[0]
+      scope.state.label = "Label Label Label"
+      scope.state.amount = null
+      scope.$digest()
 
-        expect(scope.paymentRequestURL()).toBe('https://blockchain.info/payment_request?address=1asdf&message=Label%20Label%20Label')
+      expect(scope.paymentRequestURL()).toBe('https://blockchain.info/payment_request?address=1asdf&message=Label%20Label%20Label')
 
-      it "should generate a bitcoin url with a message param instead of a label", ->
-        scope.state.to = scope.legacyAddresses()[0]
-        scope.state.label = "This is a message, though we save it as a label"
-        scope.$digest()
+    it "should contain amountType", ->
+      scope.state.to = scope.legacyAddresses()[0]
+      scope.state.label = "Label Label Label"
+      scope.state.amountType = 'amount_local'
+      scope.state.amount = 100
+      scope.$digest()
 
-        expect(scope.paymentRequestURL()).toContain('message')
-        expect(scope.paymentRequestURL()).not.toContain('label=')
+      expect(scope.paymentRequestURL()).toContain('amount_local=')
+    
+    it "should generate a bitcoin url with a message param instead of a label", ->
+      scope.state.to = scope.legacyAddresses()[0]
+      scope.state.label = "This is a message, though we save it as a label"
+      scope.$digest()
+
+      expect(scope.paymentRequestURL()).toContain('message')
+      expect(scope.paymentRequestURL()).not.toContain('label=')

--- a/tests/controllers/request_ctrl_spec.coffee
+++ b/tests/controllers/request_ctrl_spec.coffee
@@ -176,3 +176,14 @@ describe "RequestCtrl", ->
 
       expect(scope.paymentRequestURL()).toContain('message')
       expect(scope.paymentRequestURL()).not.toContain('label=')
+  
+  describe "resetCopy()", ->
+    
+    it "should reset copy buttons", ->
+      scope.state.isAddressCopied = true
+      scope.state.isBitcoinURICopied = true
+      scope.state.isPaymentRequestCopied = true
+      scope.resetCopy()
+      expect(scope.state.isAddressCopied).toBe(false)
+      expect(scope.state.isBitcoinURICopied).toBe(false)
+      expect(scope.state.isPaymentRequestCopied).toBe(false)


### PR DESCRIPTION
1. Swaps btc and fiat fields
2. Uses last amount type entered for generating request
3. Reset's copy when amounts or label is changed
4. Adds tests for paymentRequestURL function