### PR TITLE
Require filenames like my-little-pony.controller.js

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,5 +2,14 @@
   "parserOptions": {
     "ecmaVersion": 6
   },
-  "extends": "plugin:angular/johnpapa"
+  "extends": "plugin:angular/johnpapa",
+  "rules": {
+    "angular/file-name": [
+      2,
+      {
+        "typeSeparator": "dot",
+        "nameStyle": "dash"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Directives and components already follow this filename convention, but controllers don't. I'll start renaming stuff if you're happy with the new rule.