### PR TITLE
Extract constants

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,5 +2,14 @@
   "parserOptions": {
     "ecmaVersion": 6
   },
-  "extends": "plugin:angular/johnpapa"
+  "extends": "plugin:angular/johnpapa",
+  "rules": {
+    "angular/file-name": [
+      2,
+      {
+        "typeSeparator": "dot",
+        "nameStyle": "dash"
+      }
+    ]
+  }
 }

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -54,7 +54,7 @@ module.exports = (grunt) ->
 
       js:
         expand: true
-        src: ['build/js/app.js']
+        src: ['build/js/wallet-app.module.js']
         dest: ''
 
     concat:
@@ -79,7 +79,7 @@ module.exports = (grunt) ->
           "build/js/sharedDirectives/video-container.directive.js"
           "build/js/sharedDirectives/scroll-in-view.directive.js"
           "build/js/translations.js"
-          "build/js/app.js"
+          "build/js/wallet-app.module.js"
           'build/js/landingCtrl.js'
           'build/js/routes.js'
           "build/js/services/bcTranslationLoader.service.js"
@@ -456,7 +456,7 @@ module.exports = (grunt) ->
 
     replace:
       root_url:
-        src: ['build/js/app.js'],
+        src: ['build/js/wallet-app.module.js'],
         overwrite: true,
         replacements: [{
           from: 'customRootURL = $rootScope.rootURL'
@@ -505,7 +505,7 @@ module.exports = (grunt) ->
           to: () => "network = '" + @network + "'"
         }]
       version_frontend:
-        src: ['build/js/app.js'],
+        src: ['build/js/wallet-app.module.js'],
         overwrite: true,
         replacements: [{
           from: 'versionFrontend = null'
@@ -513,7 +513,7 @@ module.exports = (grunt) ->
             "versionFrontend = '" + @versionFrontend + "'"
         }]
       version_my_wallet:
-        src: ['build/js/app.js'],
+        src: ['build/js/wallet-app.module.js'],
         overwrite: true,
         replacements: [{
           from: 'versionMyWallet = null'

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -80,6 +80,7 @@ module.exports = (grunt) ->
           "build/js/sharedDirectives/scroll-in-view.directive.js"
           "build/js/translations.js"
           "build/js/wallet-app.module.js"
+          "build/js/whats-new.constant.js"
           'build/js/landingCtrl.js'
           'build/js/routes.js'
           "build/js/services/bcTranslationLoader.service.js"

--- a/app/index.pug
+++ b/app/index.pug
@@ -40,7 +40,7 @@ html(
       // include: "type": "js", "files": "build/js/sharedDirectives.js"
       // include: "type": "js", "files": "build/js/sharedDirectives/*.js"
       // include: "type": "js", "files": "build/js/translations.js"
-      // include: "type": "js", "files": "build/js/app.js"
+      // include: "type": "js", "files": "build/js/wallet-app.module.js"
       // include: "type": "js", "files": "build/js/landingCtrl.js"
       // include: "type": "js", "files": "build/js/services/bcTranslationLoader.service.js"
       // include: "type": "js", "files": "build/js/services/languages.service.js"

--- a/app/index.pug
+++ b/app/index.pug
@@ -41,6 +41,7 @@ html(
       // include: "type": "js", "files": "build/js/sharedDirectives/*.js"
       // include: "type": "js", "files": "build/js/translations.js"
       // include: "type": "js", "files": "build/js/wallet-app.module.js"
+      // include: "type": "js", "files": "build/js/whats-new.constant.js"
       // include: "type": "js", "files": "build/js/landingCtrl.js"
       // include: "type": "js", "files": "build/js/services/bcTranslationLoader.service.js"
       // include: "type": "js", "files": "build/js/services/languages.service.js"

--- a/assets/js/wallet-app.module.js
+++ b/assets/js/wallet-app.module.js
@@ -1,10 +1,9 @@
-'use strict';
-
 let debugLog = [];
 let log = console.log.bind(console);
 console.log = (...args) => { debugLog.push(args); log(...args); };
 console.replay = () => debugLog.forEach(l => log(...l));
 
+/* eslint-disable angular/window-service */
 if (browserDetection().browser === 'ie' && browserDetection().version < 11) {
   if (confirm("Your browser is out of date! It looks like you're using an old version of Internet Explorer. For the best Blockchain experience, please update your browser or hit cancel to return to our homepage.")) {
     window.location = 'http://browsehappy.com/';
@@ -12,6 +11,7 @@ if (browserDetection().browser === 'ie' && browserDetection().version < 11) {
     window.location = 'https://blockchain.info/';
   }
 }
+/* eslint-enable angular/window-service */
 
 const modules = [
   'ngAnimate',

--- a/assets/js/wallet-app.module.js
+++ b/assets/js/wallet-app.module.js
@@ -76,14 +76,6 @@ angular.module('walletApp', modules)
     }]
   });
 })
-.constant('whatsNew', [
-  { title: 'BUY_BITCOIN', desc: 'BUY_BITCOIN_EXPLAIN', date: new Date('12/15/2016'), ref: 'wallet.common.buy-sell' },
-  { title: 'EXPORT_HISTORY', desc: 'EXPORT_HISTORY_EXPLAIN', date: 1466521300000 },
-  { title: 'WHATS_NEW', desc: 'WHATS_NEW_EXPLAIN', date: 1463716800000 },
-  { title: 'SIGN_VERIFY', desc: 'SIGN_VERIFY_EXPLAIN', date: 1462161600000 },
-  { title: 'TRANSFER_ALL', desc: 'TRANSFER_ALL_EXPLAIN', date: 1461556800000 },
-  { title: 'DEV_THEMES', desc: 'DEV_THEMES_EXPLAIN', date: 1474862400000 }
-])
 .run(($rootScope, $window, $uibModal, $state, $q, $timeout, $location, languages) => {
   $rootScope.$safeApply = (scope = $rootScope, before) => {
     before = before;

--- a/assets/js/whats-new.constant.js
+++ b/assets/js/whats-new.constant.js
@@ -1,0 +1,9 @@
+angular.module('walletApp')
+.constant('whatsNew', [
+  { title: 'BUY_BITCOIN', desc: 'BUY_BITCOIN_EXPLAIN', date: new Date('12/15/2016'), ref: 'wallet.common.buy-sell' },
+  { title: 'EXPORT_HISTORY', desc: 'EXPORT_HISTORY_EXPLAIN', date: 1466521300000 },
+  { title: 'WHATS_NEW', desc: 'WHATS_NEW_EXPLAIN', date: 1463716800000 },
+  { title: 'SIGN_VERIFY', desc: 'SIGN_VERIFY_EXPLAIN', date: 1462161600000 },
+  { title: 'TRANSFER_ALL', desc: 'TRANSFER_ALL_EXPLAIN', date: 1461556800000 },
+  { title: 'DEV_THEMES', desc: 'DEV_THEMES_EXPLAIN', date: 1474862400000 }
+]);

--- a/check_bad_strings.rb
+++ b/check_bad_strings.rb
@@ -20,7 +20,7 @@ regex = /window\.open/
 Dir.glob(['assets/js/**/*.js']) do |path|
   matches = File.read(path).match(regex)
   if matches
-    if path == "assets/js/app.js" && matches.length <= 1
+    if path == "assets/js/wallet-app.module.js" && matches.length <= 1
       break
     end
     puts path + " contains window.open, use $rootScope.safeWindowOpen() instaed"

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -64,7 +64,7 @@ module.exports = function (config) {
       'assets/js/sharedDirectives/*.directive.js': ['babel', 'coverage'],
       'assets/js/core/*.service.js': ['babel'],
       'assets/js/routes.js': ['babel', 'coverage'],
-      'assets/js/app.js': ['babel'],
+      'assets/js/wallet-app.module.js': ['babel'],
       'assets/js/landingCtrl.js': ['babel', 'coverage'],
       'tests/**/*.coffee': ['coffee'],
       'tests/**/*.js': ['babel']


### PR DESCRIPTION
Depends on #1092; I can redo it if we change that rule.

The first commit renames the file, removes the unneeded `use strict` and ignores the linter warning around the browser detection code (since that is non-angular code anyway).

The second commit moves the What's new constants into its own file.

I'm pretty sure this doesn't break grunt (dist), but that might need some double checking.