### PR TITLE
Allow iSX iframe to open new tabs

### DIFF
--- a/assets/js/directives/isignthis.directive.js
+++ b/assets/js/directives/isignthis.directive.js
@@ -14,7 +14,7 @@ function isignthis ($sce, Options) {
     template: `
       <iframe
         ng-src='{{ url }}'
-        sandbox='allow-same-origin allow-scripts allow-forms'
+        sandbox='allow-same-origin allow-scripts allow-forms allow-popups allow-top-navigation'
         scrolling = 'no'
         id='isx-iframe'
         ng-if='showFrame'


### PR DESCRIPTION
This is so that the legal / help links in the iframe can bring the user to the correct url, rather than doing nothing. @Sjors @kristovatlas would be great if you can confirm that this is ok security-wise.