### PR TITLE
Use LocalStorage instead of cookies

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -74,6 +74,7 @@ module.exports = (grunt) ->
           'bower_components/angular-ui-select/dist/select.js'
           'bower_components/ng-file-upload/ng-file-upload-shim.min.js'
           'bower_components/ng-file-upload/ng-file-upload.min.js'
+          'bower_components/angular-local-storage/dist/angular-local-storage.min.js'
           "build/js/shared.module.js"
           "build/js/sharedDirectives/*.js"
           "build/js/sharedServices/*.js"

--- a/app/index.pug
+++ b/app/index.pug
@@ -36,6 +36,7 @@ html(
       script(src='bower_components/angular-ui-select/dist/select.js', defer)
       script(src='bower_components/ng-file-upload/ng-file-upload-shim.min.js', defer)
       script(src='bower_components/ng-file-upload/ng-file-upload.min.js', defer)
+      script(src='bower_components/angular-local-storage/dist/angular-local-storage.min.js', defer)
 
       // include: "type": "js", "files": "build/js/shared.module.js"
       // include: "type": "js", "files": "build/js/sharedDirectives/*.js"

--- a/assets/js/controllers/buySell.controller.js
+++ b/assets/js/controllers/buySell.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('BuySellCtrl', BuySellCtrl);
 
-function BuySellCtrl ($rootScope, AngularHelper, $scope, $state, Alerts, Wallet, currency, buySell, MyWallet, $cookies, $q, options, $stateParams, modals) {
+function BuySellCtrl ($rootScope, AngularHelper, $scope, $state, Alerts, Wallet, currency, buySell, MyWallet, $q, options, $stateParams, modals) {
   $scope.buySellStatus = buySell.getStatus;
   $scope.trades = buySell.trades;
 

--- a/assets/js/controllers/buySellMaster.controller.js
+++ b/assets/js/controllers/buySellMaster.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('BuySellMasterController', BuySellMasterController);
 
-function BuySellMasterController ($scope, $timeout, $state, MyWallet, $cookies, cta) {
+function BuySellMasterController ($scope, $timeout, $state, MyWallet, cta) {
   cta.setBuyCtaDismissed();
 
   this.base = 'wallet.common.buy-sell';

--- a/assets/js/controllers/coinify/coinify.controller.js
+++ b/assets/js/controllers/coinify/coinify.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('CoinifyController', CoinifyController);
 
-function CoinifyController ($scope, $filter, $q, MyWallet, Wallet, MyWalletHelpers, Alerts, currency, $uibModalInstance, trade, buyOptions, $timeout, $interval, formatTrade, buySell, $rootScope, $cookies, $window, $state, options, buyMobile) {
+function CoinifyController ($scope, $filter, $q, MyWallet, Wallet, MyWalletHelpers, Alerts, currency, $uibModalInstance, trade, buyOptions, $timeout, $interval, formatTrade, buySell, $rootScope, $window, $state, options, buyMobile) {
   $scope.settings = Wallet.settings;
   $scope.btcCurrency = $scope.settings.btcCurrency;
   $scope.currencies = currency.coinifyCurrencies;

--- a/assets/js/controllers/coinify/coinifySell.controller.js
+++ b/assets/js/controllers/coinify/coinifySell.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('CoinifySellController', CoinifySellController);
 
-function CoinifySellController ($scope, $filter, $q, MyWallet, Wallet, MyWalletHelpers, Alerts, currency, $uibModalInstance, trade, buySellOptions, $timeout, $interval, formatTrade, buySell, $rootScope, $cookies, $window, country, accounts, $state, smartAccount, options, $stateParams) {
+function CoinifySellController ($scope, $filter, $q, MyWallet, Wallet, MyWalletHelpers, Alerts, currency, $uibModalInstance, trade, buySellOptions, $timeout, $interval, formatTrade, buySell, $rootScope, $window, country, accounts, $state, smartAccount, options, $stateParams) {
   $scope.fields = {};
   $scope.settings = Wallet.settings;
   $scope.btcCurrency = $scope.settings.btcCurrency;

--- a/assets/js/controllers/login.controller.js
+++ b/assets/js/controllers/login.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('LoginCtrl', LoginCtrl);
 
-function LoginCtrl ($scope, $rootScope, $window, $cookies, $state, $stateParams, $timeout, $q, Alerts, Wallet, WalletNetwork) {
+function LoginCtrl ($scope, $rootScope, $window, $cookies, localStorageService, $state, $stateParams, $timeout, $q, Alerts, Wallet, WalletNetwork) {
   $scope.settings = Wallet.settings;
   $scope.user = Wallet.user;
 
@@ -13,8 +13,8 @@ function LoginCtrl ($scope, $rootScope, $window, $cookies, $state, $stateParams,
   $scope.uid = $stateParams.uid || Wallet.guid || $cookies.get('uid');
   $scope.uidAvailable = !!$scope.uid;
 
-  if ($cookies.get('password')) {
-    $scope.password = $cookies.get('password');
+  if (localStorageService.get('password')) {
+    $scope.password = localStorageService.get('password');
   }
 
   $scope.login = () => {
@@ -22,7 +22,7 @@ function LoginCtrl ($scope, $rootScope, $window, $cookies, $state, $stateParams,
     Alerts.clear();
 
     if ($scope.autoReload && $scope.password) {
-      $cookies.put('password', $scope.password);
+      localStorageService.set('password', $scope.password);
     }
 
     let success = () => {

--- a/assets/js/controllers/login.controller.js
+++ b/assets/js/controllers/login.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('LoginCtrl', LoginCtrl);
 
-function LoginCtrl ($scope, $rootScope, $window, $cookies, localStorageService, $state, $stateParams, $timeout, $q, Alerts, Wallet, WalletNetwork) {
+function LoginCtrl ($scope, $rootScope, $window, localStorageService, $state, $stateParams, $timeout, $q, Alerts, Wallet, WalletNetwork) {
   $scope.settings = Wallet.settings;
   $scope.user = Wallet.user;
 
@@ -10,7 +10,7 @@ function LoginCtrl ($scope, $rootScope, $window, $cookies, localStorageService, 
   $scope.status = {};
   $scope.browser = { disabled: true };
 
-  $scope.uid = $stateParams.uid || Wallet.guid || $cookies.get('uid');
+  $scope.uid = $stateParams.uid || Wallet.guid || localStorageService.get('guid');
   $scope.uidAvailable = !!$scope.uid;
 
   if (localStorageService.get('password')) {
@@ -59,7 +59,7 @@ function LoginCtrl ($scope, $rootScope, $window, $cookies, localStorageService, 
 
     if (Wallet.settings.twoFactorMethod === 5) {
       $scope.status.resending = true;
-      let sessionToken = $cookies.get('session');
+      let sessionToken = localStorageService.get('session');
       $q.resolve(WalletNetwork.resendTwoFactorSms($scope.uid, sessionToken))
         .then(success, error).finally(() => $scope.status.resending = false);
     }

--- a/assets/js/controllers/logout.controller.js
+++ b/assets/js/controllers/logout.controller.js
@@ -2,15 +2,15 @@ angular
   .module('walletApp')
   .controller('LogoutController', LogoutController);
 
-function LogoutController ($scope, $cookies, $q, $timeout, $interval, $state, $window, Wallet, Alerts) {
+function LogoutController ($scope, localStorageService, $q, $timeout, $interval, $state, $window, Wallet, Alerts) {
   $scope.timeToRedirect = 10;
   $scope.toLogin = () => { $state.go('public.login-no-uid'); };
 
   $scope.deauth = () => {
     $scope.deauthorizing = true;
     $scope.timeToRedirect = -1;
-    let sessionToken = $cookies.get('session');
-    $cookies.remove('session');
+    let sessionToken = localStorageService.get('session');
+    localStorageService.remove('session');
 
     $q.resolve(Wallet.my.endSession(sessionToken))
       .then(() => $scope.deauthorized = true)

--- a/assets/js/controllers/navigation.controller.js
+++ b/assets/js/controllers/navigation.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('NavigationCtrl', NavigationCtrl);
 
-function NavigationCtrl ($scope, $window, $rootScope, BrowserHelper, $state, $interval, $timeout, $cookies, $q, $uibModal, Wallet, Alerts, currency, whatsNew, MyWallet, buyStatus) {
+function NavigationCtrl ($scope, $window, $rootScope, BrowserHelper, $state, $interval, $timeout, localStorageService, $q, $uibModal, Wallet, Alerts, currency, whatsNew, MyWallet, buyStatus) {
   $scope.status = Wallet.status;
   $scope.settings = Wallet.settings;
 
@@ -11,7 +11,7 @@ function NavigationCtrl ($scope, $window, $rootScope, BrowserHelper, $state, $in
   $scope.whatsNewTemplate = 'templates/whats-new.pug';
   $scope.lastViewedWhatsNew = null;
 
-  $rootScope.isSubscribed = $cookies.get('subscribed');
+  $rootScope.isSubscribed = localStorageService.get('subscribed');
 
   $scope.getTheme = () => $scope.settings.theme;
 
@@ -24,14 +24,14 @@ function NavigationCtrl ($scope, $window, $rootScope, BrowserHelper, $state, $in
           .then(asyncAssert)
           .then(res => res.lastViewed)
       )
-      .catch(() => $cookies.get('whatsNewViewed'))
+      .catch(() => localStorageService.get('whatsNewViewed'))
       .then(value => value || lastViewedDefaultTime);
 
   $scope.viewedWhatsNew = () => {
     let lastViewed = $scope.lastViewedWhatsNew = Date.now();
     asyncAssert($scope.metaData && !Wallet.settings.secondPassword)
       .then(() => $scope.metaData.update({ lastViewed }))
-      .finally(() => $cookies.put('whatsNewViewed', lastViewed));
+      .finally(() => localStorageService.set('whatsNewViewed', lastViewed));
   };
 
   $scope.getNLatestFeats = (feats = [], lastViewed) => (
@@ -52,8 +52,8 @@ function NavigationCtrl ($scope, $window, $rootScope, BrowserHelper, $state, $in
 
     let options = (ops) => angular.merge({ friendly: true, modalClass: 'top' }, ops);
     let saidNoThanks = (e) => e === 'cancelled' ? $q.resolve() : $q.reject();
-    let hasNotSeen = (id) => !$cookies.get(id);
-    let rememberChoice = (id) => () => $cookies.put(id, true);
+    let hasNotSeen = (id) => !localStorageService.get(id);
+    let rememberChoice = (id) => () => localStorageService.set(id, true);
 
     let goToBackup = () => $q.all([$state.go('wallet.common.security-center', {promptBackup: true}), $q.reject('backing_up')]);
     let openSurvey = () => { BrowserHelper.safeWindowOpen('https://blockchain.co1.qualtrics.com/SE/?SID=SV_7PupfD2KjBeazC5'); };

--- a/assets/js/controllers/recoverFunds.controller.js
+++ b/assets/js/controllers/recoverFunds.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('RecoverFundsCtrl', RecoverFundsCtrl);
 
-function RecoverFundsCtrl ($scope, AngularHelper, $state, $timeout, $translate, $cookies, Wallet, Alerts) {
+function RecoverFundsCtrl ($scope, AngularHelper, $state, $timeout, $translate, localStorageService, Wallet, Alerts) {
   $scope.isValidMnemonic = Wallet.isValidBIP39Mnemonic;
   $scope.currentStep = 1;
   $scope.fields = {
@@ -19,8 +19,8 @@ function RecoverFundsCtrl ($scope, AngularHelper, $state, $timeout, $translate, 
     $scope.working = true;
 
     const success = (result) => {
-      $cookies.put('session', result.sessionToken);
-      $cookies.put('uid', result.guid);
+      localStorageService.set('session', result.sessionToken);
+      localStorageService.set('guid', result.guid);
 
       $scope.working = false;
       $scope.nextStep();

--- a/assets/js/controllers/resetTwoFactor.controller.js
+++ b/assets/js/controllers/resetTwoFactor.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('ResetTwoFactorCtrl', ResetTwoFactorCtrl);
 
-function ResetTwoFactorCtrl ($scope, $cookies, $q, $sce, Alerts, Wallet, WalletNetwork) {
+function ResetTwoFactorCtrl ($scope, localStorageService, $q, $sce, Alerts, Wallet, WalletNetwork) {
   $scope.currentStep = 1;
 
   $scope.fields = {
@@ -13,7 +13,7 @@ function ResetTwoFactorCtrl ($scope, $cookies, $q, $sce, Alerts, Wallet, WalletN
     captcha: ''
   };
 
-  $scope.fields.uid = $cookies.get('uid');
+  $scope.fields.uid = localStorageService.get('guid');
 
   $scope.refreshCaptcha = () => $q.resolve(
     WalletNetwork.getCaptchaImage().then((data) => {

--- a/assets/js/controllers/sfox/sfoxCreateAccount.controller.js
+++ b/assets/js/controllers/sfox/sfoxCreateAccount.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('SfoxCreateAccountController', SfoxCreateAccountController);
 
-function SfoxCreateAccountController ($scope, AngularHelper, $timeout, $q, $cookies, Wallet, Alerts, sfox, bcPhoneNumber) {
+function SfoxCreateAccountController ($scope, AngularHelper, $timeout, $q, localStorageService, Wallet, Alerts, sfox, bcPhoneNumber) {
   const views = ['summary', 'email', 'mobile'];
   const cookieIds = { SENT_EMAIL: 'sentEmailCode', SENT_MOBILE: 'sentMobileCode' };
   let exchange = $scope.vm.exchange;
@@ -10,8 +10,8 @@ function SfoxCreateAccountController ($scope, AngularHelper, $timeout, $q, $cook
 
   let state = $scope.state = {
     terms: false,
-    sentEmailCode: $cookies.getObject(cookieIds.SENT_EMAIL),
-    sentMobileCode: $cookies.getObject(cookieIds.SENT_MOBILE),
+    sentEmailCode: localStorageService.get(cookieIds.SENT_EMAIL),
+    sentMobileCode: localStorageService.get(cookieIds.SENT_MOBILE),
     get verified () { return this.verifiedEmail && this.verifiedMobile; }
   };
 
@@ -112,20 +112,20 @@ function SfoxCreateAccountController ($scope, AngularHelper, $timeout, $q, $cook
   $scope.$watch('state.view', (view) => {
     let shouldSendEmail =
       !state.verifiedEmail &&
-      !$cookies.getObject('sentEmailCode') &&
+      !localStorageService.get('sentEmailCode') &&
       state.email &&
       state.email.indexOf('@') > -1;
 
     let shouldSendMobile =
       !state.verifiedMobile &&
-      !$cookies.getObject('sentMobileCode') &&
+      !localStorageService.get('sentMobileCode') &&
       bcPhoneNumber.isValid(state.mobile);
 
     if (view === 'email' && shouldSendEmail) $scope.sendEmailCode();
     if (view === 'mobile' && shouldSendMobile) $scope.sendMobileCode();
   });
 
-  let syncCookie = (id) => $cookies.putObject.bind($cookies, id);
+  let syncCookie = (id) => localStorageService.set.bind(localStorageService, id);
   $scope.$watch('state.sentEmailCode', syncCookie(cookieIds.SENT_EMAIL));
   $scope.$watch('state.sentMobileCode', syncCookie(cookieIds.SENT_MOBILE));
 

--- a/assets/js/controllers/signup.controller.js
+++ b/assets/js/controllers/signup.controller.js
@@ -2,9 +2,9 @@ angular
   .module('walletApp')
   .controller('SignupCtrl', SignupCtrl);
 
-SignupCtrl.$inject = ['$scope', '$state', '$cookies', '$filter', '$timeout', '$translate', 'Wallet', 'currency', 'languages', 'MyWallet', '$http', 'Env'];
+SignupCtrl.$inject = ['$scope', '$state', 'localStorageService', '$filter', '$timeout', '$translate', 'Wallet', 'currency', 'languages', 'MyWallet', '$http', 'Env'];
 
-function SignupCtrl ($scope, $state, $cookies, $filter, $timeout, $translate, Wallet, currency, languages, MyWallet, $http, Env) {
+function SignupCtrl ($scope, $state, localStorageService, $filter, $timeout, $translate, Wallet, currency, languages, MyWallet, $http, Env) {
   $scope.working = false;
   $scope.browser = {disabled: true};
 
@@ -161,7 +161,7 @@ function SignupCtrl ($scope, $state, $cookies, $filter, $timeout, $translate, Wa
     $scope.working = true;
 
     if ($scope.autoReload) {
-      $cookies.put('password', $scope.fields.password);
+      localStorageService.set('password', $scope.fields.password);
     }
 
     $timeout(() => {

--- a/assets/js/controllers/subscribe.controller.js
+++ b/assets/js/controllers/subscribe.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('SubscribeCtrl', SubscribeCtrl);
 
-function SubscribeCtrl ($rootScope, $scope, MyWallet, country, state, buySell, $cookies, $uibModalStack) {
+function SubscribeCtrl ($rootScope, $scope, MyWallet, country, state, buySell, localStorageService, $uibModalStack) {
   $scope.countries = country;
   $scope.states = state;
   $scope.data = {};
@@ -19,7 +19,7 @@ function SubscribeCtrl ($rootScope, $scope, MyWallet, country, state, buySell, $
   };
 
   $scope.subscribe = () => {
-    $cookies.put('subscribed', true);
+    localStorageService.set('subscribed', true);
     $rootScope.isSubscribed = true;
     $uibModalStack.dismissAll();
   };

--- a/assets/js/controllers/wallet.controller.js
+++ b/assets/js/controllers/wallet.controller.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .controller('WalletCtrl', WalletCtrl);
 
-function WalletCtrl ($scope, $rootScope, Wallet, $uibModal, $timeout, Alerts, $interval, $ocLazyLoad, $state, $uibModalStack, $q, $cookies, MyWallet, currency, $translate, $window, buyStatus, modals) {
+function WalletCtrl ($scope, $rootScope, Wallet, $uibModal, $timeout, Alerts, $interval, $ocLazyLoad, $state, $uibModalStack, $q, localStorageService, MyWallet, currency, $translate, $window, buyStatus, modals) {
   $scope.goal = Wallet.goal;
 
   $scope.status = Wallet.status;
@@ -115,7 +115,7 @@ function WalletCtrl ($scope, $rootScope, Wallet, $uibModal, $timeout, Alerts, $i
 
   $scope.$on('$stateChangeSuccess', (event, toState, toParams, fromState, fromParams) => {
     if (!$scope.isPublicState(toState.name) && !$scope.status.isLoggedIn) {
-      let showLogout = $window.name === 'blockchain-logout' && $cookies.get('session');
+      let showLogout = $window.name === 'blockchain-logout' && localStorageService.get('session');
       $state.go(`public.${showLogout ? 'logout' : 'login-no-uid'}`);
     }
     $rootScope.outOfApp = toState.name === 'landing';

--- a/assets/js/directives/pulse-cta.directive.js
+++ b/assets/js/directives/pulse-cta.directive.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .directive('pulseCta', pulseCta);
 
-pulseCta.$inject = ['$cookies'];
+pulseCta.$inject = [];
 
 function pulseCta () {
   const directive = {

--- a/assets/js/services/alerts.service.js
+++ b/assets/js/services/alerts.service.js
@@ -2,9 +2,9 @@ angular
   .module('walletApp')
   .factory('Alerts', Alerts);
 
-Alerts.$inject = ['$timeout', '$rootScope', 'BrowserHelper', '$q', '$translate', '$uibModal', '$uibModalStack', '$cookies'];
+Alerts.$inject = ['$timeout', '$rootScope', 'BrowserHelper', '$q', '$translate', '$uibModal', '$uibModalStack', 'localStorageService'];
 
-function Alerts ($timeout, $rootScope, BrowserHelper, $q, $translate, $uibModal, $uibModalStack, $cookies) {
+function Alerts ($timeout, $rootScope, BrowserHelper, $q, $translate, $uibModal, $uibModalStack, localStorageService) {
   const service = {
     alerts: [],
     close,
@@ -73,7 +73,7 @@ function Alerts ($timeout, $rootScope, BrowserHelper, $q, $translate, $uibModal,
 
   function surveyCloseConfirm (survey, links, index, sell) {
     let link = links[index];
-    let surveyOpened = $cookies.getObject(survey);
+    let surveyOpened = localStorageService.get(survey);
 
     let hasSeenPrompt = !links.length ||
                         index >= links.length ||
@@ -85,7 +85,7 @@ function Alerts ($timeout, $rootScope, BrowserHelper, $q, $translate, $uibModal,
       }
       return service.confirm('CONFIRM_CLOSE_BUY', {action: 'IM_DONE'});
     } else {
-      $cookies.putObject(survey, {index: index});
+      localStorageService.set(survey, {index: index});
       let openSurvey = () => BrowserHelper.safeWindowOpen(link);
       return service.confirm('SURVEY_PROMPT', {action: 'TAKE_SURVEY', friendly: true, cancel: 'NO_THANKS'})
                     .then(openSurvey)

--- a/assets/js/services/buy-status.service.js
+++ b/assets/js/services/buy-status.service.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .factory('buyStatus', buyStatus);
 
-function buyStatus ($rootScope, Wallet, MyWallet, MyWalletHelpers, Options, $cookies, Alerts, $state, $q) {
+function buyStatus ($rootScope, Wallet, MyWallet, MyWalletHelpers, Options, localStorageService, Alerts, $state, $q) {
   const service = {};
 
   let isCountryWhitelisted = null;
@@ -61,7 +61,7 @@ function buyStatus ($rootScope, Wallet, MyWallet, MyWalletHelpers, Options, $coo
 
   // check to make sure this does not get called on home
   service.shouldShowBuyReminder = () => {
-    let buyReminder = $cookies.getObject('buy-bitcoin-reminder');
+    let buyReminder = localStorageService.get('buy-bitcoin-reminder');
     let timeHasPassed = buyReminder ? new Date() > buyReminder.when : true;
     let shownTwice = buyReminder ? buyReminder.index >= 2 : false;
     let firstTime = Wallet.goal.firstTime;
@@ -71,7 +71,7 @@ function buyStatus ($rootScope, Wallet, MyWallet, MyWalletHelpers, Options, $coo
   };
 
   service.showBuyReminder = () => {
-    let buyReminder = $cookies.getObject('buy-bitcoin-reminder');
+    let buyReminder = localStorageService.get('buy-bitcoin-reminder');
 
     let options = (ops) => angular.merge({ friendly: true, modalClass: 'top' }, ops);
     let saidNoThanks = (e) => e === 'cancelled' ? $q.resolve() : $q.reject();
@@ -82,7 +82,7 @@ function buyStatus ($rootScope, Wallet, MyWallet, MyWalletHelpers, Options, $coo
     Alerts.confirm('BUY_BITCOIN_REMINDER', options({cancel: 'NO_THANKS', action: 'GET_BITCOIN', iconClass: 'hide'}))
           .then(goToBuy, saidNoThanks);
 
-    $cookies.putObject('buy-bitcoin-reminder', {
+    localStorageService.set('buy-bitcoin-reminder', {
       index: nextIndex,
       when: nextWeek()
     });

--- a/assets/js/services/cta.service.js
+++ b/assets/js/services/cta.service.js
@@ -2,7 +2,7 @@ angular
   .module('walletApp')
   .factory('cta', cta);
 
-function cta ($cookies, Wallet, buyStatus) {
+function cta (localStorageService, Wallet, buyStatus) {
   const cookieJar = {};
   const ONE_WEEK = 604800000;
   const BUY_CTA_KEY = 'buy-alert-seen';
@@ -21,18 +21,18 @@ function cta ($cookies, Wallet, buyStatus) {
   return service;
 
   function cacheCookies () {
-    cookieJar[BUY_CTA_KEY] = $cookies.get(BUY_CTA_KEY);
-    cookieJar[SECURITY_WARNING_KEY] = $cookies.getObject(SECURITY_WARNING_KEY);
+    cookieJar[BUY_CTA_KEY] = localStorageService.get(BUY_CTA_KEY);
+    cookieJar[SECURITY_WARNING_KEY] = localStorageService.get(SECURITY_WARNING_KEY);
   }
 
   function shouldShowBuyCta () {
     let hasAccount = buyStatus.userHasAccount();
-    let hasSeenCta = cookieJar[BUY_CTA_KEY] === 'true';
+    let hasSeenCta = cookieJar[BUY_CTA_KEY];
     return !hasAccount && !hasSeenCta;
   }
 
   function setBuyCtaDismissed () {
-    $cookies.put(BUY_CTA_KEY, true);
+    localStorageService.set(BUY_CTA_KEY, true);
     cacheCookies();
   }
 
@@ -52,7 +52,7 @@ function cta ($cookies, Wallet, buyStatus) {
     let messageCookie = cookieJar[SECURITY_WARNING_KEY];
     let index = messageCookie ? messageCookie.index + 1 : 0;
     let when = nextWeek();
-    $cookies.putObject(SECURITY_WARNING_KEY, { index, when });
+    localStorageService.set(SECURITY_WARNING_KEY, { index, when });
     cacheCookies();
   }
 

--- a/assets/js/services/wallet.service.js
+++ b/assets/js/services/wallet.service.js
@@ -4,9 +4,9 @@ angular
   .module('walletApp')
   .factory('Wallet', Wallet);
 
-Wallet.$inject = ['$http', '$window', '$timeout', '$location', '$injector', 'Alerts', 'MyWallet', 'MyBlockchainApi', 'MyBlockchainRng', 'MyBlockchainSettings', 'MyWalletStore', 'MyWalletHelpers', '$rootScope', 'AngularHelper', 'ngAudio', '$cookies', 'localStorageService', '$translate', '$filter', '$state', '$q', 'languages', 'currency', 'theme', 'BlockchainConstants', 'Options', 'Env', 'BrowserHelper'];
+Wallet.$inject = ['$http', '$window', '$timeout', '$location', '$injector', 'Alerts', 'MyWallet', 'MyBlockchainApi', 'MyBlockchainRng', 'MyBlockchainSettings', 'MyWalletStore', 'MyWalletHelpers', '$rootScope', 'AngularHelper', 'ngAudio', 'localStorageService', '$translate', '$filter', '$state', '$q', 'languages', 'currency', 'theme', 'BlockchainConstants', 'Options', 'Env', 'BrowserHelper'];
 
-function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWallet, MyBlockchainApi, MyBlockchainRng, MyBlockchainSettings, MyWalletStore, MyWalletHelpers, $rootScope, AngularHelper, ngAudio, $cookies, localStorageService, $translate, $filter, $state, $q, languages, currency, theme, BlockchainConstants, Options, Env, BrowserHelper) {
+function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWallet, MyBlockchainApi, MyBlockchainRng, MyBlockchainSettings, MyWalletStore, MyWalletHelpers, $rootScope, AngularHelper, ngAudio, localStorageService, $translate, $filter, $state, $q, languages, currency, theme, BlockchainConstants, Options, Env, BrowserHelper) {
   BrowserHelper.migrateCookiesToLocalStorage();
   const wallet = {
     goal: {
@@ -69,8 +69,8 @@ function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWalle
 
     if ($window.location.hostname === 'localhost' || !env.isProduction) {
       const KEY = 'qa-tools-enabled';
-      env.buySellDebug = $cookies.get(KEY) === 'true';
-      let reloadWithDebug = (debug) => { $cookies.put(KEY, debug); $window.location.reload(); };
+      env.buySellDebug = localStorageService.get(KEY);
+      let reloadWithDebug = (debug) => { localStorageService.set(KEY, debug); $window.location.reload(); };
       $window.enableQA = () => reloadWithDebug(true);
       $window.disableQA = () => reloadWithDebug(false);
     }
@@ -235,7 +235,7 @@ function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWalle
       wallet.setLanguage($filter('getByProperty')('code', result.language, languages.languages));
       wallet.settings.btcCurrency = $filter('getByProperty')('serverCode', result.btc_currency, currency.bitCurrencies);
       wallet.settings.displayCurrency = wallet.settings.btcCurrency;
-      wallet.settings.theme = $filter('getByProperty')('name', $cookies.get('theme'), theme.themes) || theme.themes[0];
+      wallet.settings.theme = $filter('getByProperty')('name', localStorageService.get('theme'), theme.themes) || theme.themes[0];
       wallet.settings.feePerKB = wallet.my.wallet.fee_per_kb;
       wallet.settings.blockTOR = !!result.block_tor_ips;
       wallet.status.didLoadSettings = true;
@@ -695,7 +695,7 @@ function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWalle
     }
     // TODO: fix autoreload dev feature
     // if ($rootScope.autoReload) {
-    //   $cookies.put('reload.url', $location.url())
+    //   localStorageService.set('reload.url', $location.url())
     // }
   };
 
@@ -794,7 +794,7 @@ function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWalle
     } else if (event === 'logging_out') {
       if (wallet.autoLogout) {
         $translate('LOGGED_OUT_AUTOMATICALLY').then((translation) => {
-          $cookies.put('alert-warning', translation);
+          localStorageService.set('alert-warning', translation);
         });
       }
       wallet.status.isLoggedIn = false;
@@ -833,15 +833,15 @@ function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWalle
     wallet.monitor(event, data);
   });
 
-  let message = $cookies.get('alert-warning');
+  let message = localStorageService.get('alert-warning');
   if (message !== void 0 && message !== null) {
     Alerts.displayWarning(message, true);
-    $cookies.remove('alert-warning');
+    localStorageService.remove('alert-warning');
   }
-  message = $cookies.get('alert-success');
+  message = localStorageService.get('alert-success');
   if (message !== void 0 && message !== null) {
     Alerts.displaySuccess(message);
-    $cookies.remove('alert-success');
+    localStorageService.remove('alert-success');
   }
 
   wallet.setNote = (tx, text) => {
@@ -878,7 +878,7 @@ function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWalle
   });
 
   wallet.changeTheme = (theme) => $q((resolve, reject) => {
-    $cookies.put('theme', theme.name);
+    localStorageService.set('theme', theme.name);
     resolve(true);
   });
 
@@ -1064,7 +1064,7 @@ function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWalle
     let success = () => {
       wallet.settings.rememberTwoFactor = false;
       // This takes effect immedidately:
-      $cookies.remove('session');
+      localStorageService.remove('session');
       successCallback();
       AngularHelper.$safeApply();
     };
@@ -1162,7 +1162,7 @@ function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWalle
       // Check which metadata service features we use:
 
       // This falls back to cookies if 2nd password is enabled:
-      let lastViewed = $cookies.get('whatsNewViewed');
+      let lastViewed = localStorageService.get('whatsNewViewed');
 
       if (lastViewed) {
         let whatsNew = wallet.my.wallet.metadata(2);
@@ -1206,7 +1206,7 @@ function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWalle
     let whatsNew = wallet.my.wallet.metadata(2);
     whatsNew.fetch().then((res) => {
       if (res !== null) {
-        $cookies.put('whatsNewViewed', res.lastViewed);
+        localStorageService.set('whatsNewViewed', res.lastViewed);
       }
     }).catch(() => {
       throw new Error("saving your What's New view status failed");

--- a/assets/js/services/wallet.service.js
+++ b/assets/js/services/wallet.service.js
@@ -4,9 +4,10 @@ angular
   .module('walletApp')
   .factory('Wallet', Wallet);
 
-Wallet.$inject = ['$http', '$window', '$timeout', '$location', '$injector', 'Alerts', 'MyWallet', 'MyBlockchainApi', 'MyBlockchainRng', 'MyBlockchainSettings', 'MyWalletStore', 'MyWalletHelpers', '$rootScope', 'AngularHelper', 'ngAudio', '$cookies', '$translate', '$filter', '$state', '$q', 'languages', 'currency', 'theme', 'BlockchainConstants', 'Options', 'Env'];
+Wallet.$inject = ['$http', '$window', '$timeout', '$location', '$injector', 'Alerts', 'MyWallet', 'MyBlockchainApi', 'MyBlockchainRng', 'MyBlockchainSettings', 'MyWalletStore', 'MyWalletHelpers', '$rootScope', 'AngularHelper', 'ngAudio', '$cookies', 'localStorageService', '$translate', '$filter', '$state', '$q', 'languages', 'currency', 'theme', 'BlockchainConstants', 'Options', 'Env', 'BrowserHelper'];
 
-function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWallet, MyBlockchainApi, MyBlockchainRng, MyBlockchainSettings, MyWalletStore, MyWalletHelpers, $rootScope, AngularHelper, ngAudio, $cookies, $translate, $filter, $state, $q, languages, currency, theme, BlockchainConstants, Options, Env) {
+function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWallet, MyBlockchainApi, MyBlockchainRng, MyBlockchainSettings, MyWalletStore, MyWalletHelpers, $rootScope, AngularHelper, ngAudio, $cookies, localStorageService, $translate, $filter, $state, $q, languages, currency, theme, BlockchainConstants, Options, Env, BrowserHelper) {
+  BrowserHelper.migrateCookiesToLocalStorage();
   const wallet = {
     goal: {
       auth: false,
@@ -160,8 +161,8 @@ function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWalle
       // Immedidately store the new guid and session token, in case the user needs
       // to refresh their browser:
       const newSessionToken = (token) => {
-        $cookies.put('session', token);
-        $cookies.put('uid', uid);
+        localStorageService.set('session', token);
+        localStorageService.set('guid', uid);
       };
 
       wallet.my.login(
@@ -185,8 +186,8 @@ function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWalle
     };
 
     // Check if we already have a session token:
-    let sessionToken = $cookies.get('session');
-    let sessionGuid = $cookies.get('uid');
+    let sessionToken = localStorageService.get('session');
+    let sessionGuid = localStorageService.get('guid');
 
     doLogin(uid, sessionGuid, sessionToken);
   };
@@ -307,8 +308,8 @@ function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWalle
 
   wallet.create = (password, email, currency, language, success_callback) => {
     let success = (uid, sharedKey, password, sessionToken) => {
-      $cookies.put('session', sessionToken);
-      $cookies.put('uid', uid);
+      localStorageService.set('session', sessionToken);
+      localStorageService.set('guid', uid);
       Alerts.displaySuccess('Wallet created with identifier: ' + uid);
       wallet.goal.firstTime = true;
 
@@ -408,7 +409,7 @@ function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWalle
     let { auto = false } = options;
     wallet.autoLogout = auto;
     $window.name = wallet.askForDeauth() ? 'blockchain-logout' : 'blockchain';
-    $cookies.remove('password');
+    localStorageService.remove('password');
     wallet.my.logout(true);
   };
 

--- a/assets/js/sharedServices/browser-helper.service.js
+++ b/assets/js/sharedServices/browser-helper.service.js
@@ -16,7 +16,7 @@ function BrowserHelper ($window, $cookies, localStorageService) {
   }
 
   function migrateCookiesToLocalStorage () {
-    // Migrate any cookies to local storage:
+    // Rename uid to guid
     if ($cookies.get('uid')) {
       localStorageService.set('guid', $cookies.get('uid'));
       $cookies.remove('uid');
@@ -32,10 +32,11 @@ function BrowserHelper ($window, $cookies, localStorageService) {
           key,
           $cookies.get(key) === 'true'
         );
+        $cookies.remove(key);
       }
     }
 
-    // Convert cookie keys to localstorage
+    // Convert regular cookie keys to localstorage
     for (let key of [
       'password',
       'session',

--- a/assets/js/sharedServices/browser-helper.service.js
+++ b/assets/js/sharedServices/browser-helper.service.js
@@ -17,19 +17,56 @@ function BrowserHelper ($window, $cookies, localStorageService) {
 
   function migrateCookiesToLocalStorage () {
     // Migrate any cookies to local storage:
-    if ($cookies.get('password')) {
-      localStorageService.set('password', $cookies.get('password'));
-      $cookies.remove('password');
-    }
-
     if ($cookies.get('uid')) {
       localStorageService.set('guid', $cookies.get('uid'));
       $cookies.remove('uid');
     }
 
-    if ($cookies.get('session')) {
-      localStorageService.set('session', $cookies.get('session'));
-      $cookies.remove('session');
+    // Replace 'true' with true
+    for (let key of [
+      'qa-tools-enabled',
+      'buy-alert-seen'
+    ]) {
+      if ($cookies.get(key)) {
+        localStorageService.set(
+          key,
+          $cookies.get(key) === 'true'
+        );
+      }
+    }
+
+    // Convert cookie keys to localstorage
+    for (let key of [
+      'password',
+      'session',
+      'subscribed',
+      'whatsNewViewed',
+      'backup-reminder',
+      'logout-survey',
+      'theme',
+      'reload.url',
+      'alert-warning',
+      'alert-success'
+    ]) {
+      if ($cookies.get(key)) {
+        localStorageService.set(key, $cookies.get(key));
+        $cookies.remove(key);
+      }
+    }
+
+    // Convert cookie objects to localstorage:
+    for (let key of [
+      'buy-bitcoin-reminder',
+      'sentEmailCode',
+      'sentMobileCode',
+      'survey-opened',
+      'sfox-survey',
+      'contextual-message'
+    ]) {
+      if ($cookies.getObject(key)) {
+        localStorageService.set(key, $cookies.getObject(key));
+        $cookies.remove(key);
+      }
     }
   }
 }

--- a/assets/js/sharedServices/browser-helper.service.js
+++ b/assets/js/sharedServices/browser-helper.service.js
@@ -2,15 +2,34 @@ angular
   .module('shared')
   .factory('BrowserHelper', BrowserHelper);
 
-BrowserHelper.$inject = ['$window'];
+BrowserHelper.$inject = ['$window', '$cookies', 'localStorageService'];
 
-function BrowserHelper ($window) {
+function BrowserHelper ($window, $cookies, localStorageService) {
   return {
-    safeWindowOpen: safeWindowOpen
+    safeWindowOpen: safeWindowOpen,
+    migrateCookiesToLocalStorage: migrateCookiesToLocalStorage
   };
 
   function safeWindowOpen (url) {
     let otherWindow = $window.open(url, '_blank');
     otherWindow.opener = null;
+  }
+
+  function migrateCookiesToLocalStorage () {
+    // Migrate any cookies to local storage:
+    if ($cookies.get('password')) {
+      localStorageService.set('password', $cookies.get('password'));
+      $cookies.remove('password');
+    }
+
+    if ($cookies.get('uid')) {
+      localStorageService.set('guid', $cookies.get('uid'));
+      $cookies.remove('uid');
+    }
+
+    if ($cookies.get('session')) {
+      localStorageService.set('session', $cookies.get('session'));
+      $cookies.remove('session');
+    }
   }
 }

--- a/assets/js/wallet-app.module.js
+++ b/assets/js/wallet-app.module.js
@@ -23,6 +23,7 @@ const modules = [
   'walletTranslations',
   'walletFilters',
   'oc.lazyLoad',
+  'LocalStorageModule',
   // Not needed for landing page, but loading it now for the config step below:
   'ui.select',
   // Not needed for landing page, TODO: lazy load

--- a/assets/js/wallet-app.module.js
+++ b/assets/js/wallet-app.module.js
@@ -76,6 +76,10 @@ angular.module('walletApp', modules)
       files: bcPhoneNumberLazyLoadFiles
     }]
   });
+}).config((localStorageServiceProvider) => {
+  localStorageServiceProvider
+    // We delete existing cookies; make sure we don't go in circles.
+    .setDefaultToCookie(false);
 })
 .run(() => {
 });

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,8 @@
     "blockchain-wallet": "^3.30.10",
     "bc-phone-number": "5.1.*",
     "oclazyload": "1.0.*",
-    "ng-file-upload": "~12.2.13"
+    "ng-file-upload": "~12.2.13",
+    "angular-local-storage": "^0.5.2"
   },
   "devDependencies": {
     "compare-versions": "^2.0.1"

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,6 +27,7 @@ module.exports = function (config) {
       'bower_components/browserdetection/src/browser-detection.js',
       'bower_components/compare-versions/index.js',
       'bower_components/ng-file-upload/ng-file-upload.min.js',
+      'bower_components/angular-local-storage/dist/angular-local-storage.min.js',
       'assets/js/shared.module.js',
       'assets/js/sharedServices/*.service.js',
       'assets/js/sharedDirectives/*.directive.js',

--- a/tests/controllers/buy_sell_master_ctrl_spec.coffee
+++ b/tests/controllers/buy_sell_master_ctrl_spec.coffee
@@ -3,7 +3,6 @@ describe "BuySellMasterController", ->
   $controller = undefined
   $state = undefined
   MyWallet = undefined
-  $cookies = undefined
   cta = undefined
 
   beforeEach angular.mock.module("walletApp")
@@ -20,7 +19,7 @@ describe "BuySellMasterController", ->
       $state = _$state_
 
       MyWallet = $injector.get("MyWallet")
-      
+
       cta =
         setBuyCtaDismissed: () ->
 
@@ -29,7 +28,7 @@ describe "BuySellMasterController", ->
 
   getController = (profile, accounts, quote) ->
     $scope = $rootScope.$new()
-    
+
     $controller "BuySellMasterController",
       cta: cta
       $scope: $scope
@@ -40,18 +39,18 @@ describe "BuySellMasterController", ->
     spyOn(cta, 'setBuyCtaDismissed')
     ctrl = getController()
     expect(cta.setBuyCtaDismissed).toHaveBeenCalled()
-    
+
   describe ".resolveState()", ->
-    
+
     it "should resolve to .select if user has no exchange account", ->
       ctrl = getController()
       expect(ctrl.resolveState()).toBe('.select')
-    
+
     it "should resolve to .coinify if user has a coinify account", ->
       MyWallet.wallet.external.coinify.user = 1
       ctrl = getController()
       expect(ctrl.resolveState()).toBe('.coinify')
-    
+
     it "should resolve to .sfox if user has a sfox account", ->
       MyWallet.wallet.external.sfox.user = 1
       ctrl = getController()

--- a/tests/controllers/coinify/coinify_ctrl_spec.coffee
+++ b/tests/controllers/coinify/coinify_ctrl_spec.coffee
@@ -189,8 +189,8 @@ describe "CoinifyController", ->
     beforeEach ->
       spyOn(Alerts, 'confirm').and.callThrough()
 
-    it "should prompt for survey first", inject(($cookies) ->
-      spyOn($cookies, "getObject").and.returnValue(false)
+    it "should prompt for survey first", inject((localStorageService) ->
+      spyOn(localStorageService, "get").and.returnValue(false)
       scope.goTo('select-country')
       scope.close(true)
       expect(Alerts.confirm).toHaveBeenCalledWith('SURVEY_PROMPT', {friendly: true, action: 'TAKE_SURVEY', cancel: 'NO_THANKS'})

--- a/tests/controllers/login_ctrl_spec.coffee
+++ b/tests/controllers/login_ctrl_spec.coffee
@@ -1,7 +1,7 @@
 describe "LoginCtrl", ->
   scope = undefined
   Alerts = undefined
-  cookies = undefined
+  localStorageService = undefined
 
   modal =
    open: (args) ->
@@ -44,8 +44,8 @@ describe "LoginCtrl", ->
     scope.login()
   )
 
-  it "should resend two factor sms", inject((Wallet, WalletNetwork, $cookies) ->
-    spyOn($cookies, "get").and.callFake((name) ->
+  it "should resend two factor sms", inject((Wallet, WalletNetwork, localStorageService) ->
+    spyOn(localStorageService, "get").and.callFake((name) ->
       if name == "session"
         "token"
     )

--- a/tests/controllers/navigation_ctrl_spec.coffee
+++ b/tests/controllers/navigation_ctrl_spec.coffee
@@ -12,7 +12,7 @@ describe "NavigationCtrl", ->
   beforeEach angular.mock.module("walletApp")
 
   beforeEach ->
-    angular.mock.inject ($cookies, $injector, $rootScope, $controller, $q) ->
+    angular.mock.inject (localStorageService, $injector, $rootScope, $controller, $q) ->
       $timeout = $injector.get("$timeout")
       Wallet = $injector.get("Wallet")
       MyWallet = $injector.get("MyWallet")
@@ -55,7 +55,7 @@ describe "NavigationCtrl", ->
       Wallet.store.setIsSynchronizedWithServer(true)
 
       spyOn(Date, 'now').and.returnValue(4)
-      spyOn($cookies, 'get').and.returnValue(2)
+      spyOn(localStorageService, 'get').and.returnValue(2)
 
       scope = $rootScope.$new()
 
@@ -128,20 +128,20 @@ describe "NavigationCtrl", ->
         mockFailure = true
         scope.$digest()
 
-      it "should get the last viewed time from a cookie", ->
+      it "should get the last viewed time from localstorage", ->
         expect(scope.lastViewedWhatsNew).toEqual(2)
 
       it "should calculate the correct number of latest feats", ->
         $timeout.flush()
         expect(scope.nLatestFeats).toEqual(1)
 
-      it "should set new cookie when whats new is viewed", inject(($cookies, $timeout) ->
-        spyOn($cookies, 'put')
+      it "should store in localstorage when whats new is viewed", inject((localStorageService, $timeout) ->
+        spyOn(localStorageService, 'set')
         $timeout.flush()
         expect(scope.nLatestFeats).toEqual(1)
         scope.viewedWhatsNew()
         scope.$digest()
-        expect($cookies.put).toHaveBeenCalledWith('whatsNewViewed', 4)
+        expect(localStorageService.set).toHaveBeenCalledWith('whatsNewViewed', 4)
         $timeout.flush()
         expect(scope.nLatestFeats).toEqual(0)
       )
@@ -158,13 +158,13 @@ describe "NavigationCtrl", ->
         $timeout.flush()
         expect(scope.nLatestFeats).toEqual(1)
 
-      it "should set new cookie when whats new is viewed", inject(($cookies, $timeout) ->
-        spyOn($cookies, 'put')
+      it "should store in localstorage when whats new is viewed", inject((localStorageService, $timeout) ->
+        spyOn(localStorageService, 'set')
         $timeout.flush()
         expect(scope.nLatestFeats).toEqual(1)
         scope.viewedWhatsNew()
         scope.$digest()
-        expect($cookies.put).toHaveBeenCalledWith('whatsNewViewed', 4)
+        expect(localStorageService.set).toHaveBeenCalledWith('whatsNewViewed', 4)
         $timeout.flush()
         expect(scope.nLatestFeats).toEqual(0)
       )

--- a/tests/controllers/signup_controller_spec.coffee
+++ b/tests/controllers/signup_controller_spec.coffee
@@ -132,23 +132,23 @@ describe "SignupCtrl", ->
       expect(Wallet.create).toHaveBeenCalled()
     )
 
-    it "should add password to cookies in dev mode", inject(($cookies) ->
-      spyOn($cookies, 'put')
+    it "should add password to local storage in dev mode", inject((localStorageService) ->
+      spyOn(localStorageService, 'set')
       scope.autoReload = true
       scope.fields.password = "testing"
 
       scope.signup()
       scope.$digest()
-      expect($cookies.put).toHaveBeenCalledWith('password', "testing")
+      expect(localStorageService.set).toHaveBeenCalledWith('password', "testing")
     )
 
-    it "should not add password to cookies in production mode", inject(($cookies) ->
-      spyOn($cookies, 'put')
+    it "should not add password to local storage in production mode", inject((localStorageService) ->
+      spyOn(localStorageService, 'set')
       scope.autoReload = false
       scope.fields.password = "testing"
 
       scope.signup()
-      expect($cookies.put).not.toHaveBeenCalledWith('password', "testing")
+      expect(localStorageService.set).not.toHaveBeenCalledWith('password', "testing")
     )
 
   describe "language", ->

--- a/tests/controllers/wallet_ctrl_spec.coffee
+++ b/tests/controllers/wallet_ctrl_spec.coffee
@@ -4,7 +4,6 @@ describe "WalletCtrl", ->
   mockModalInstance = undefined
   $httpBackend = undefined
   $rootScope = undefined
-  $cookies = undefined
 
   beforeEach angular.mock.module("walletApp")
 
@@ -14,7 +13,6 @@ describe "WalletCtrl", ->
       MyWallet = $injector.get("MyWallet")
       buyStatus = $injector.get("buyStatus")
       $httpBackend = $injector.get("$httpBackend")
-      $cookies = $injector.get("$cookies")
       $rootScope.rootURL = "https://blockchain.info/"
       $rootScope.karma = true
 

--- a/tests/services/wallet/2nd_pwd_spec.coffee
+++ b/tests/services/wallet/2nd_pwd_spec.coffee
@@ -37,13 +37,13 @@ describe "walletServices 2nd pwd", () ->
       expect(Wallet.my.wallet.encrypt).toHaveBeenCalled()
     )
 
-    it "should make a cookie for whatsnew", inject(($rootScope, $cookies) ->
-      spyOn($cookies, "put")
+    it "should store whatsnew in localstorage", inject(($rootScope, localStorageService) ->
+      spyOn(localStorageService, "set")
 
       Wallet.setSecondPassword()
       $rootScope.$digest()
 
-      expect($cookies.put).toHaveBeenCalled()
+      expect(localStorageService.set).toHaveBeenCalled()
     )
 
 
@@ -62,27 +62,27 @@ describe "walletServices 2nd pwd", () ->
       expect(Wallet.my.wallet.decrypt).toHaveBeenCalled()
     )
 
-    # Delete this test after removing the cookie fallback
-    it "should use - but not delete - the cookie for whatsnew", inject(($rootScope, $cookies) ->
-      spyOn($cookies, "get").and.returnValue(2)
-      spyOn($cookies, "remove")
+    # Delete this test after removing the localstorage fallback
+    it "should use - but not delete - the localstorage entry for whatsnew", inject(($rootScope, localStorageService) ->
+      spyOn(localStorageService, "get").and.returnValue(2)
+      spyOn(localStorageService, "remove")
 
       Wallet.removeSecondPassword(callbacks.success, callbacks.error)
       $rootScope.$digest()
 
-      expect($cookies.get).toHaveBeenCalled()
-      expect($cookies.remove).not.toHaveBeenCalled()
+      expect(localStorageService.get).toHaveBeenCalled()
+      expect(localStorageService.remove).not.toHaveBeenCalled()
     )
 
-    # Uncomment the test below after removing the cookie fallback
+    # Uncomment the test below after removing the local storage fallback
 
-    # it "should use and delete the cookie for whatsnew", inject(($rootScope, $cookies) ->
-    #   spyOn($cookies, "get").and.returnValue(2)
-    #   spyOn($cookies, "remove")
+    # it "should use and delete the local storage entry for whatsnew", inject(($rootScope, localStorageService) ->
+    #   spyOn(localStorageService, "get").and.returnValue(2)
+    #   spyOn(localStorageService, "remove")
     #
     #   Wallet.removeSecondPassword(callbacks.success, callbacks.error)
     #   $rootScope.$digest()
     #
-    #   expect($cookies.get).toHaveBeenCalled()
-    #   expect($cookies.remove).toHaveBeenCalled()
+    #   expect(localStorageService.get).toHaveBeenCalled()
+    #   expect(localStorageService.remove).toHaveBeenCalled()
     # )

--- a/tests/services/wallet/signup_login_sync_upgrade.coffee
+++ b/tests/services/wallet/signup_login_sync_upgrade.coffee
@@ -220,8 +220,8 @@ describe "walletServices", () ->
     )
 
 
-    it "should add uid to cookies", inject(($cookies) ->
-      spyOn($cookies, 'put')
+    it "should add uid to cookies", inject((localStorageService) ->
+      spyOn(localStorageService, 'set')
       Wallet.create("1234567890", "a@b.com", "EUR", "EN", callbacks.success)
-      expect($cookies.put).toHaveBeenCalledWith('uid', "new_guid")
+      expect(localStorageService.set).toHaveBeenCalledWith('uid', "new_guid")
     )

--- a/tests/services/wallet_service_spec.coffee
+++ b/tests/services/wallet_service_spec.coffee
@@ -11,7 +11,7 @@ describe "walletServices", () ->
   beforeEach angular.mock.module("walletApp")
 
   beforeEach ->
-    angular.mock.inject ($injector, _$rootScope_, $q, $cookies) ->
+    angular.mock.inject ($injector, _$rootScope_, $q, localStorageService) ->
       $rootScope = _$rootScope_
       Wallet = $injector.get("Wallet")
       MyBlockchainSettings = $injector.get("MyBlockchainSettings")
@@ -22,7 +22,7 @@ describe "walletServices", () ->
       Options.get = () ->
         Promise.resolve({})
 
-      spyOn($cookies, "get").and.callFake((name) ->
+      spyOn(localStorageService, "get").and.callFake((name) ->
         if name == "session"
           "token"
       )

--- a/tests/wallet-app.module.spec.js
+++ b/tests/wallet-app.module.spec.js
@@ -7,6 +7,7 @@ const modules = [
   'ngCookies',
   'ngAnimate',
   'ngFileUpload',
+  'LocalStorageModule',
 
   'ui.select',
   'ngAudio',


### PR DESCRIPTION
All browsers that we support, support local storage.

`BrowserHelper.migrateCookiesToLocalStorage()` checks for existing cookies, deletes them and use local storage instead.