### PR TITLE
Security mobile paragraph style fix

### DIFF
--- a/assets/css/modules/_security-center.scss
+++ b/assets/css/modules/_security-center.scss
@@ -152,6 +152,7 @@
       color: rgb(117, 117, 117);
       line-height: 1.5em;
       margin: 0;
+      word-wrap: break-word;
     }
   }
   .block-tor-actions {


### PR DESCRIPTION
Fixed a small issue that caused the paragraph text to overflow the width of the container on mobile.