### PR TITLE
Export: Read utf8 properly in Excel

### DIFF
--- a/assets/js/directives/download-button.directive.js
+++ b/assets/js/directives/download-button.directive.js
@@ -16,12 +16,14 @@ function downloadButton ($window, $timeout) {
   return directive;
 
   function link (scope, attr, elem) {
+    const BYTE_ORDER_MARKER_UTF8 = '\uFEFF';
+
     scope.createDataUri = (data) => (
       `data:text/plain;charset=utf-8,${encodeURIComponent(data)}`
     );
 
     scope.$watch('content', (content) => {
-      scope.dataRef = scope.createDataUri(content);
+      scope.dataRef = scope.createDataUri(BYTE_ORDER_MARKER_UTF8 + content);
     });
 
     scope.$on('download', (event) => {

--- a/tests/directives/download-button_spec.js
+++ b/tests/directives/download-button_spec.js
@@ -14,9 +14,8 @@ describe('downloadButton', () => {
     scope.$digest();
 
     element = $compile("<download-button content='content' filename='test.txt'></download-button>")(scope);
-    return isoScope = element.isolateScope();
-  })
-  );
+    isoScope = element.isolateScope();
+  }));
 
   it('should use the correct filename', () => {
     isoScope.$digest();
@@ -26,7 +25,7 @@ describe('downloadButton', () => {
   it('should click the anchor tag to trigger download', () => {
     isoScope.$digest();
     spyOn(element[0], 'click');
-    scope.$broadcast("download");
+    scope.$broadcast('download');
     $timeout.flush();
     expect(element[0].click).toHaveBeenCalled();
   });
@@ -34,15 +33,17 @@ describe('downloadButton', () => {
   describe('content', () => {
     beforeEach(function () {
       spyOn(isoScope, 'createDataUri').and.callFake(x => `data:${x}`);
-      return isoScope.$digest();
+      isoScope.$digest();
     });
 
-    it('should create an initial data ref', () => expect(isoScope.dataRef).toEqual('data:asdf'));
+    it('should create an initial data ref', () =>
+      expect(isoScope.dataRef).toEqual('data:\uFEFFasdf')
+    );
 
     it('should create a data ref when updated', () => {
       isoScope.content = 'abc';
       isoScope.$digest();
-      expect(isoScope.dataRef).toEqual('data:abc');
+      expect(isoScope.dataRef).toEqual('data:\uFEFFabc');
     });
   });
 


### PR DESCRIPTION
Prepending this special character tells Excel to import the csv file as utf8, so that currency symbols don't get mangled in the resulting spreadsheet. This has been tested in Excel (on Mac), Google Sheets, and some text editors. Behaves as expected in all, although a review by someone who knows more about this than I do would be nice.