### PR TITLE
Correctly stack mediums on mobile

### DIFF
--- a/app/partials/coinify/medium.pug
+++ b/app/partials/coinify/medium.pug
@@ -1,6 +1,6 @@
 form.bc-form.modal-body.fade.clearfix(name="paymentMethodForm" id="paymentMethodForm" role="form" ng-submit="submit()" novalidate)
   span.type-h5.em-500.flex-start.pts(translate="PAYMENT_METHOD")
-  .radio-group.group.inline.flex-column-mobile.flex-between.mv-20
+  .radio-group.flex-column-mobile.flex-between.mv-20
     .radio-label-alt.width-45(ng-show="aboveBankMin && !pendingKYC()")
       input(type="radio" name="inMedium" id="bank" ng-model="vm.medium" value="bank" required)
       label.flex-column.height-100(for="bank")


### PR DESCRIPTION
Removing these classes stacks the payment mediums on mobile width