### PR TITLE
Use new priority fee for sell

### DIFF
--- a/assets/js/components/sell-quick-start.component.js
+++ b/assets/js/components/sell-quick-start.component.js
@@ -182,6 +182,7 @@ function sellQuickStartController ($scope, $rootScope, currency, buySell, Alerts
   $scope.offerUseAll = (payment, paymentInfo) => {
     this.error['moreThanInWallet'] = true;
     this.status.busy = true;
+    payment.updateFeePerKb(paymentInfo.fees.priority);
     $scope.payment = Wallet.my.wallet.createPayment(payment);
     $scope.maxSpendableAmount = paymentInfo.sweepAmount;
     let maxSweepFee = paymentInfo.sweepFee;

--- a/assets/js/controllers/coinify/coinifySell.controller.js
+++ b/assets/js/controllers/coinify/coinifySell.controller.js
@@ -138,11 +138,8 @@ function CoinifySellController ($scope, Wallet, Alerts, currency, $uibModalInsta
 
   $scope.startPayment = () => {
     if (this.trade.state) return;
-    let firstBlockFee = this.payment.absoluteFeeBounds[0];
-    if ($scope.isSweepTransaction) firstBlockFee = this.payment.sweepFees[0];
     this.finalPayment = Wallet.my.wallet.createPayment(this.payment);
-    this.finalPayment.fee(firstBlockFee);
-    this.transaction.fee.btc = currency.convertFromSatoshi(firstBlockFee, currency.bitCurrencies[0]);
+    this.transaction.fee.btc = currency.convertFromSatoshi(this.payment.finalFee, currency.bitCurrencies[0]);
     this.transaction.btcAfterFee = parseFloat((this.transaction.btc + this.transaction.fee.btc).toFixed(8));
     return {transaction: this.transaction};
   };

--- a/tests/components/sell-quick-start_spec.js
+++ b/tests/components/sell-quick-start_spec.js
@@ -124,13 +124,18 @@ describe('sell-quick-start.component', () => {
   });
 
   describe('offerUseAll()', () => {
-    it('should set maxSpendableAmount to the first number in the array', () => {
+    it('should set maxSpendableAmount', () => {
       getController(handlers);
       let paymentInfo = {
         sweepAmount: 1,
-        sweepFee: 1
+        sweepFee: 1,
+        fees: {
+          priority: 1
+        }
       };
-      let payment = {};
+      let payment = {
+        updateFeePerKb: () => {}
+      };
       scope.offerUseAll(payment, paymentInfo);
       expect(scope.maxSpendableAmount).toEqual(1);
     });

--- a/tests/controllers/coinify/coinify_sell_spec.js
+++ b/tests/controllers/coinify/coinify_sell_spec.js
@@ -86,8 +86,10 @@ describe('CoinifySellController', () => {
       }) ;
 
       payment = {
-        absoluteFeeBounds: [100,100,100,100,100,100],
-        sweepFees: [50,50,50,50,50,50]
+        fees: {
+          priority: 100
+        },
+        sweepFee: 50
       };
       return {
         buySell: {


### PR DESCRIPTION
This will use the new fee service for sell, defaulting to the priority fee for < 1 hr confirmation time.