### PR TITLE
Destinations

### DIFF
--- a/assets/css/modules/_send-receive.scss
+++ b/assets/css/modules/_send-receive.scss
@@ -9,6 +9,19 @@
   }
 }
 
+#send,
+#receive,
+#sign-msg {
+  .dropdown-menu {
+    > li:first-child {
+      .dropdown-header {
+        // we need to remove this when we come up with what we want to call Accounts
+        display: none;
+      }
+    }
+  }
+}
+
 #send, #sign-msg {
   .inprv {
     bottom: -12px;
@@ -17,14 +30,6 @@
     overflow-y: auto;
     max-height: 160px;
     overflow-x: hidden;
-  }
-  .dropdown-menu {
-    > li:first-child {
-      .dropdown-header {
-        // we need to remove this when we come up with what we want to call Accounts
-        display: none;
-      }
-    }
   }
   .row {
     @extend .flex-row;

--- a/assets/js/controllers/export-history.controller.js
+++ b/assets/js/controllers/export-history.controller.js
@@ -10,7 +10,7 @@ function ExportHistoryController ($scope, $timeout, $translate, browser, format,
   let addresses = Wallet.legacyAddresses().filter(a => !a.archived).map(a => a.address);
   let all_accounts = {
     index: '',
-    label: $translate.instant('ALL_ACCOUNTS'),
+    label: $translate.instant('ALL_WALLETS'),
     address: accounts.map(a => a.extendedPublicKey).concat(addresses)
   };
   let imported_addresses = {

--- a/assets/js/controllers/transactions.controller.js
+++ b/assets/js/controllers/transactions.controller.js
@@ -22,7 +22,7 @@ function TransactionsCtrl ($scope, AngularHelper, $q, $translate, $uibModal, Wal
   $scope.isFilterOpen = false;
   $scope.toggleFilter = () => $scope.isFilterOpen = !$scope.isFilterOpen;
 
-  let all = { label: $translate.instant('ALL_ACCOUNTS'), index: '', type: 'Accounts' };
+  let all = { label: $translate.instant('ALL_WALLETS'), index: '', type: 'Accounts' };
   $scope.accounts = smartAccount.getOptions();
   if ($scope.accounts.length > 1) $scope.accounts.unshift(all);
   $scope.filterBy.account = $scope.accounts[0];

--- a/assets/js/services/wallet.service.js
+++ b/assets/js/services/wallet.service.js
@@ -752,7 +752,7 @@ function Wallet ($http, $window, $timeout, $location, $injector, Alerts, MyWalle
     let input = tx.processedInputs
       .filter(i => !i.change)[0] || tx.processedInputs[0];
     let outputs = tx.processedOutputs
-      .filter(o => !o.change && o.address !== input.address);
+      .filter(o => !o.change);
 
     let setLabel = (io) => (
       io.label = io.label || wallet.getAddressBookLabel(io.address) || io.address

--- a/locales/en-human.json
+++ b/locales/en-human.json
@@ -667,7 +667,7 @@
   "MOBILE_NUMBER_TOOLTIP" : "@:MOBILE_NUMBER_EXPLAIN",
   "2FA_TOOLTIP" : "2-Step Verification helps prevent unauthorized access to your wallet by requiring a one-time password after every login attempt.",
   "BLOCK_TOR_TOOLTIP" : "Prevent IP addresses that are known to be part of the Tor anonymizing network from accessing your wallet.",
-  "ALL_ACCOUNTS" : "All Accounts",
+  "ALL_WALLETS" : "All Wallets",
   "ALL_TRANSACTIONS": "All Transactions",
   "NOTE_LC" : "Note:",
   "SECURE_WALLET_MSG_1" : "We’re thrilled you’re using your bitcoin wallet! But it looks like you’re still not as secure as you could be. Securing your wallet can help keep funds safe.",


### PR DESCRIPTION
It looks like at one point 'destinations' in the transaction were outputs filtered by `!change`, but then we added another check to make sure they were not the same address as an input. https://github.com/blockchain/My-Wallet-V3-Frontend/commit/e396f6040c17bc45118e67f46a7bbb47622daf35#diff-d055a71329975bd2903700e75dd34665L16. It was a year ago, not sure if anyone knows why.

I snuck a translation fix for 'All Accounts' in here as well. Here is the important change: https://github.com/blockchain/My-Wallet-V3-Frontend/pull/1160/files#diff-ec46870014d4acb6e20b619fc6379da0R755