### PR TITLE
BTC Conversion Fix

### DIFF
--- a/assets/js/services/currency.service.js
+++ b/assets/js/services/currency.service.js
@@ -218,8 +218,8 @@ function currency ($q, MyBlockchainApi, MyWalletHelpers) {
     if (amount == null || currency == null) return null;
     if (isBitCurrency(currency) || isBchCurrency(currency)) {
       return amount / currency.conversion;
-    } else if (conversions[currency.code] != null) {
-      return conversions[currency.code].conversion ? amount / conversions[currency.code].conversion : 0;
+    } else if (conversions[currency.code] != null && conversions[currency.code].conversion) {
+      return amount / conversions[currency.code].conversion;
     } else if (currency.conversion) {
       return Math.ceil(amount * currency.conversion);
     } else {

--- a/assets/js/services/currency.service.js
+++ b/assets/js/services/currency.service.js
@@ -219,7 +219,7 @@ function currency ($q, MyBlockchainApi, MyWalletHelpers) {
     if (isBitCurrency(currency) || isBchCurrency(currency)) {
       return amount / currency.conversion;
     } else if (conversions[currency.code] != null) {
-      return amount / conversions[currency.code].conversion;
+      return conversions[currency.code].conversion ? amount / conversions[currency.code].conversion : 0;
     } else if (currency.conversion) {
       return Math.ceil(amount * currency.conversion);
     } else {

--- a/tests/mocks/my_wallet/my_blockchain_api_mock.js
+++ b/tests/mocks/my_wallet/my_blockchain_api_mock.js
@@ -11,7 +11,8 @@ angular
     getExchangeRate (curr) {
       let result = {
         EUR: {'15m': 250, last: 250, buy: 250, sell: 250, symbol: '€'},
-        USD: {'15m': 300, last: 300, buy: 300, sell: 300, symbol: '$'}
+        USD: {'15m': 300, last: 300, buy: 300, sell: 300, symbol: '$'},
+        INR: {'15m': 0, last: 0, buy: 0, sell: 0, symbol: 'INR'}
       };
       return $q.resolve(result);
     },

--- a/tests/services/currency.service.spec.js
+++ b/tests/services/currency.service.spec.js
@@ -156,6 +156,11 @@ describe('currency', () => {
       let conversion = currency.convertFromSatoshi(10000, currency.currencies[1]);
       expect(conversion).toEqual(0.025);
     }));
+
+    it('should return null if currency conversion is 0', inject((currency) => {
+      let conversion = currency.convertFromSatoshi(10000, currency.currencies[2]);
+      expect(conversion).toEqual(null);
+    }));
   });
 
   describe('formatCurrencyForView()', () => {


### PR DESCRIPTION
This handles problems caused by dividing a num by 0 and then performing an operation on it (NaN). Only for BTC right now.