### PR TITLE
Dynamically determine earliest history export start date

### DIFF
--- a/assets/js/controllers/export-history.controller.js
+++ b/assets/js/controllers/export-history.controller.js
@@ -41,7 +41,7 @@ function ExportHistoryController ($scope, $timeout, $translate, browser, format,
   vm.active = vm.activeCount === 1 ? all_accounts : vm.targets.filter(t => t.index.toString() === activeIndex)[0];
 
   vm.options = {
-    minDate: DateHelper.bitcoinStartDate,
+    minDate: coinCode === 'btc' ? DateHelper.bitcoinStartDate : DateHelper.bitcoinCashStartDate,
     maxDate: DateHelper.now()
   };
 

--- a/assets/js/services/date-helper.service.js
+++ b/assets/js/services/date-helper.service.js
@@ -5,18 +5,18 @@ angular
 // TODO: Integrate moment.js later
 
 function DateHelper ($filter) {
-  let epochBitcoinStartDate = 1231024500000;
-
   // Properties
+  let bitcoinStartDate = new Date(1231024500000); // Jan 3, 2009
+  let bitcoinCashStartDate = new Date(1501628400000); // Aug 1, 2017
   let format = {
     shortDate: 'dd/MM/yyyy'
   };
 
-  let bitcoinStartDate = new Date(epochBitcoinStartDate);
-
-  let now = () => { return new Date(); };
-
   // Methods
+  let now = () => { return new Date(); };
+  let toShortDate = (d) => $filter('date')(d, format.shortDate);
+  let toCustomShortDate = (sep, d) => $filter('date')(d, `dd${sep}MM${sep}yyyy`);
+  
   let round = (d) => {
     d = new Date(d);
     d.setHours(0);
@@ -32,13 +32,10 @@ function DateHelper ($filter) {
     return d;
   };
 
-  let toShortDate = (d) => $filter('date')(d, format.shortDate);
-
-  let toCustomShortDate = (sep, d) => $filter('date')(d, `dd${sep}MM${sep}yyyy`);
-
   return {
     format: format,
     bitcoinStartDate: bitcoinStartDate,
+    bitcoinCashStartDate: bitcoinCashStartDate,
     now: now,
     round: round,
     subtractDays: subtractDays,

--- a/assets/js/services/date-helper.service.js
+++ b/assets/js/services/date-helper.service.js
@@ -16,7 +16,7 @@ function DateHelper ($filter) {
   let now = () => { return new Date(); };
   let toShortDate = (d) => $filter('date')(d, format.shortDate);
   let toCustomShortDate = (sep, d) => $filter('date')(d, `dd${sep}MM${sep}yyyy`);
-  
+
   let round = (d) => {
     d = new Date(d);
     d.setHours(0);

--- a/tests/controllers/export-history.controller.spec.js
+++ b/tests/controllers/export-history.controller.spec.js
@@ -78,12 +78,12 @@ describe('ExportHistoryController2', () => {
     
       it('btc min start date should be Jan 3, 2009', () => {
         let controller = createController('', 'btc');
-        expect(controller.options.minDate.toString()).toEqual('Sat Jan 03 2009 18:15:00 GMT-0500 (EST)');
+        expect(controller.options.minDate.toString().startsWith('Sat Jan 03 2009')).toBeTruthy();
       });
   
       it('bch min start date should be Aug 1, 2017', () => {
         let controller = createController('', 'bch');
-        expect(controller.options.minDate.toString()).toEqual('Tue Aug 01 2017 19:00:00 GMT-0400 (EDT)');
+        expect(controller.options.minDate.toString().startsWith('Tue Aug 01 2017')).toBeTruthy();
       });
     });
     

--- a/tests/controllers/export-history.controller.spec.js
+++ b/tests/controllers/export-history.controller.spec.js
@@ -47,13 +47,13 @@ describe('ExportHistoryController2', () => {
 
     }));
 
-    let createController = (activeIndex) => {
+    let createController = (activeIndex, coinCode) => {
 
         return $controller('ExportHistoryController', {
             $scope: $rootScope.$new(),
             activeIndex: activeIndex,
             accts: { accounts: Wallet.accounts().filter((w) => !w.archived), addresses: Wallet.legacyAddresses().filter((w) => !w.archived) },
-            coinCode: 'btc'
+            coinCode: coinCode ? coinCode : 'btc'
         });
     };
 
@@ -73,7 +73,20 @@ describe('ExportHistoryController2', () => {
         let controller = createController('');
         expect(controller.active.address).toEqual(['xpub1']);
     });
-
+  
+    describe('startDateLimits', () => {
+    
+      it('btc min start date should be Jan 3, 2009', () => {
+        let controller = createController('', 'btc');
+        expect(controller.options.minDate.toString()).toEqual('Sat Jan 03 2009 18:15:00 GMT-0500 (EST)');
+      });
+  
+      it('bch min start date should be Aug 1, 2017', () => {
+        let controller = createController('', 'bch');
+        expect(controller.options.minDate.toString()).toEqual('Tue Aug 01 2017 19:00:00 GMT-0400 (EDT)');
+      });
+    });
+    
     describe('activeIndex', () => {
 
         it('should set all when "" ', () => {

--- a/tests/controllers/export-history.controller.spec.js
+++ b/tests/controllers/export-history.controller.spec.js
@@ -53,7 +53,7 @@ describe('ExportHistoryController2', () => {
             $scope: $rootScope.$new(),
             activeIndex: activeIndex,
             accts: { accounts: Wallet.accounts().filter((w) => !w.archived), addresses: Wallet.legacyAddresses().filter((w) => !w.archived) },
-            coinCode: coinCode ? coinCode : 'btc'
+            coinCode: coinCode || 'btc'
         });
     };
 


### PR DESCRIPTION
**Overview**:
Fixes issue where users could choose a BCH history export start date before the actual existence of BCH (August 1, 2017).  

**Changes**:
- Added BCH chain start date property to `date-helper.service.js`
- Added a `coinCode` check to `export-history.controller.js` to dynamically determine the appropriate  earliest history start date
- Wrote unit tests for both BTC and BCH scenarios