### PR TITLE
Ensure all coin pairs show minimum deposit amount for ShapeShift transactions

### DIFF
--- a/assets/js/components/shapeshift/shift-create.component.js
+++ b/assets/js/components/shapeshift/shift-create.component.js
@@ -156,7 +156,7 @@ function ShiftCreateController (Env, AngularHelper, $translate, $scope, $q, curr
   $scope.$watch('$ctrl.to.coinCode', () => state.baseInput && $scope.refreshIfValid('input'));
   $scope.$watch('state.input.amount', () => state.baseInput && $scope.refreshIfValid('input'));
   $scope.$watch('state.output.amount', () => !state.baseInput && $scope.refreshIfValid('output'));
-  $scope.$watchGroup(['$ctrl.from.balance', '$ctrl.to.balance'], (n, o) => { if (n !== o) { getRate().then($scope.getAvailableBalance); } });
+  $scope.$watchGroup(['$ctrl.from.coinCode', '$ctrl.to.coinCode'], (n, o) => { if (n !== o) { getRate().then($scope.getAvailableBalance); } });
 
   // Stat: how often do users see the "max limit" error?
   let sawMaxLimit = false;

--- a/tests/components/shapeshift/shift-create_spec.js
+++ b/tests/components/shapeshift/shift-create_spec.js
@@ -199,9 +199,9 @@ describe('shift-create.component', () => {
     });
 
     describe('from', () => {
-      it('should getAvailableBalance when balance changes', () => {
+      it('should getAvailableBalance when coinCode changes', () => {
         spyOn(scope, 'getAvailableBalance');
-        scope.$ctrl.from.balance = 100;
+        scope.$ctrl.from.coinCode = 'bch';
         scope.$digest();
         expect(scope.getAvailableBalance).toHaveBeenCalled();
       });


### PR DESCRIPTION
Fixes issue where minimum deposit amount messages were not displaying when users selected BCH as the outbound currency in a ShapeShift transaction.