### PR TITLE
Order wallets and then addresses by value

### DIFF
--- a/app/partials/send/send-bitcoin-cash.pug
+++ b/app/partials/send/send-bitcoin-cash.pug
@@ -25,9 +25,11 @@
                 required)
                 ui-select-match(placeholder="{{'SEARCH' | translate}}...")
                   label-origin(origin="$select.selected" ng-class="{'state-danger-text': $select.selected.balance === 0}" coin-code="'bch'")
-                ui-select-choices(repeat="origin in origins | filter:{label:$select.search} | limitTo:originLimit" group-by="'type'" ui-disable-choice="::hasZeroBalance(origin)")
+                ui-select-choices(repeat="origin in origins | filter:{label:$select.search} | orderBy:'-balance' | limitTo:originLimit" group-by="'type'" ui-disable-choice="::hasZeroBalance(origin)")
                   span(ng-class="::{aaa:hasZeroBalance(origin)}" in-view="$last && origin.type==='Imported Addresses' && increaseLimit()")
-                    label-origin(origin="::origin" highlight="$select.search" coin-code="'bch'")
+                    label-origin(
+                      origin="::origin" highlight="$select.search" coin-code="'bch'" truncate-display="true"
+                      uib-tooltip="{{::origin.address}}" tooltip-append-to-body="true" tooltip-placement="top" tooltip-class="address" tooltip-popup-delay="500")
 
               //- Private Key for Watch Only
               .input-group.pbm(ng-show="transaction.from.isWatchOnly")

--- a/app/partials/send/send-bitcoin-cash.pug
+++ b/app/partials/send/send-bitcoin-cash.pug
@@ -29,7 +29,8 @@
                   span(ng-class="::{aaa:hasZeroBalance(origin)}" in-view="$last && origin.type==='Imported Addresses' && increaseLimit()")
                     label-origin(
                       origin="::origin" highlight="$select.search" coin-code="'bch'" truncate-display="true"
-                      uib-tooltip="{{::origin.address}}" tooltip-append-to-body="true" tooltip-placement="top" tooltip-class="address" tooltip-popup-delay="500")
+                      uib-tooltip="{{::origin.address}}" tooltip-append-to-body="true" tooltip-placement="top"
+                      tooltip-class="address" tooltip-popup-delay="500")
 
               //- Private Key for Watch Only
               .input-group.pbm(ng-show="transaction.from.isWatchOnly")

--- a/app/partials/send/send-bitcoin.pug
+++ b/app/partials/send/send-bitcoin.pug
@@ -32,7 +32,8 @@
                   span(ng-class="::{aaa:hasZeroBalance(origin)}" in-view="$last && origin.type==='Imported Addresses' && increaseLimit()")
                     label-origin(
                       origin="::origin" highlight="$select.search" truncate-display="true"
-                      uib-tooltip="{{::origin.address}}" tooltip-append-to-body="true" tooltip-placement="top" tooltip-class="address" tooltip-popup-delay="500")
+                      uib-tooltip="{{::origin.address}}" tooltip-append-to-body="true" tooltip-placement="top"
+                      tooltip-class="address" tooltip-popup-delay="500")
 
               //- Private Key for Watch Only
               .input-group.pbm(ng-show="transaction.from.isWatchOnly")

--- a/app/partials/send/send-bitcoin.pug
+++ b/app/partials/send/send-bitcoin.pug
@@ -28,9 +28,11 @@
                 required)
                 ui-select-match(placeholder="{{'SEARCH' | translate}}...")
                   label-origin(origin="$select.selected" ng-class="{'state-danger-text': $select.selected.balance === 0}")
-                ui-select-choices(repeat="origin in origins | filter:{label:$select.search} | limitTo:originLimit" group-by="'type'" ui-disable-choice="::hasZeroBalance(origin)")
+                ui-select-choices(repeat="origin in origins | filter:{label:$select.search} | orderBy:'-balance' | limitTo:originLimit" group-by="'type'" ui-disable-choice="::hasZeroBalance(origin)")
                   span(ng-class="::{aaa:hasZeroBalance(origin)}" in-view="$last && origin.type==='Imported Addresses' && increaseLimit()")
-                    label-origin(origin="::origin" highlight="$select.search")
+                    label-origin(
+                      origin="::origin" highlight="$select.search" truncate-display="true"
+                      uib-tooltip="{{::origin.address}}" tooltip-append-to-body="true" tooltip-placement="top" tooltip-class="address" tooltip-popup-delay="500")
 
               //- Private Key for Watch Only
               .input-group.pbm(ng-show="transaction.from.isWatchOnly")

--- a/app/templates/label-origin.pug
+++ b/app/templates/label-origin.pug
@@ -1,7 +1,7 @@
 span
   span(
     ng-show="$ctrl.origin"
-    ng-bind-html="($ctrl.origin.label || $ctrl.origin.address) | escapeHtml | highlight:$ctrl.highlight"
+    ng-bind-html="($ctrl.displayValue || $ctrl.origin.label || $ctrl.origin.address) | escapeHtml | highlight:$ctrl.highlight"
     translate="no")
 span(ng-hide="$ctrl.simple && $ctrl.origin.type !== 'Accounts'")
   span(ng-hide="$ctrl.origin.balance == null") &ensp;({{ $ctrl.origin.balance | convert:$ctrl.type:true:$ctrl.coin }})&ensp;

--- a/assets/css/modules/_send-receive.scss
+++ b/assets/css/modules/_send-receive.scss
@@ -8,9 +8,6 @@
       display: block;
       overflow: hidden;
       height: 1.428571429em;
-      @media (max-width: 767px) {
-        max-width: 200px;
-      }
     }
   }
 }

--- a/assets/js/components/label-origin.component.js
+++ b/assets/js/components/label-origin.component.js
@@ -11,15 +11,15 @@ angular
     templateUrl: 'templates/label-origin.pug',
     controller: function (Wallet, currency) {
       let display = Wallet.settings.displayCurrency;
-      
+
       this.coin = this.coinCode || 'btc';
       this.type = currency.isBitCurrency(display) ? this.coin : 'fiat';
-      
+
       if (this.origin && this.truncateDisplay) {
         this.displayValue = this.origin.label || this.origin.address;
-        
+
         if (this.displayValue.length > 22) {
-          this.displayValue = this.displayValue.substring(0,22) + '...';
+          this.displayValue = this.displayValue.substring(0, 22) + '...';
         }
       }
     }

--- a/assets/js/components/label-origin.component.js
+++ b/assets/js/components/label-origin.component.js
@@ -5,13 +5,22 @@ angular
       origin: '<',
       highlight: '<',
       coinCode: '<',
-      simple: '<'
+      simple: '<',
+      truncateDisplay: '<'
     },
     templateUrl: 'templates/label-origin.pug',
     controller: function (Wallet, currency) {
       let display = Wallet.settings.displayCurrency;
-
+      
       this.coin = this.coinCode || 'btc';
       this.type = currency.isBitCurrency(display) ? this.coin : 'fiat';
+      
+      if (this.origin && this.truncateDisplay) {
+        this.displayValue = this.origin.label || this.origin.address;
+        
+        if (this.displayValue.length > 22) {
+          this.displayValue = this.displayValue.substring(0,22) + '...';
+        }
+      }
     }
   });

--- a/assets/js/controllers/send/sendBitcoin.controller.js
+++ b/assets/js/controllers/send/sendBitcoin.controller.js
@@ -107,7 +107,7 @@ function SendBitcoinController ($scope, AngularHelper, $log, Wallet, Alerts, cur
   $scope.setPaymentHandlers($scope.payment);
 
   $scope.hasZeroBalance = (origin) => origin.balance === 0;
-  
+
   $scope.applyPaymentRequest = (paymentRequest, i) => {
     let destination = {
       address: paymentRequest.address || '',

--- a/assets/js/controllers/send/sendBitcoin.controller.js
+++ b/assets/js/controllers/send/sendBitcoin.controller.js
@@ -108,10 +108,6 @@ function SendBitcoinController ($scope, AngularHelper, $log, Wallet, Alerts, cur
 
   $scope.hasZeroBalance = (origin) => origin.balance === 0;
   
-  $scope.orderGroups = (a,b) => {
-   // debugger;
-  }
-
   $scope.applyPaymentRequest = (paymentRequest, i) => {
     let destination = {
       address: paymentRequest.address || '',

--- a/assets/js/controllers/send/sendBitcoin.controller.js
+++ b/assets/js/controllers/send/sendBitcoin.controller.js
@@ -107,6 +107,10 @@ function SendBitcoinController ($scope, AngularHelper, $log, Wallet, Alerts, cur
   $scope.setPaymentHandlers($scope.payment);
 
   $scope.hasZeroBalance = (origin) => origin.balance === 0;
+  
+  $scope.orderGroups = (a,b) => {
+   // debugger;
+  }
 
   $scope.applyPaymentRequest = (paymentRequest, i) => {
     let destination = {


### PR DESCRIPTION
- Fixes an issue where users with many wallets and imported addresses were unable to quickly find wallets/addresses of value when sending funds.
- Truncates imported addresses to ensure the address holding amount is displayed in the dropdown options.
- Added hover text to addresses that will show the full addresses after 500 milliseconds.
- Removed some unnecessary CSS
