### PR TITLE
Fix download button

### DIFF
--- a/assets/js/directives/download-button.directive.js
+++ b/assets/js/directives/download-button.directive.js
@@ -10,7 +10,7 @@ function downloadButton ($window, $timeout) {
       filename: '@',
       content: '='
     },
-    template: '<a href="{{dataRef}}" download="{{filename}}" target="_blank" rel="noopener noreferrer">{{::"DOWNLOAD"|translate}}</a>',
+    template: '<a href="{{dataRef}}" download="{{filename}}" rel="noopener noreferrer">{{::"DOWNLOAD"|translate}}</a>',
     link: link
   };
   return directive;


### PR DESCRIPTION
For some reason this was causing the export history function to not work. It would quickly open and close a new tab instead of actually triggering a download. Weird, since this directive hasn't been touched in a long time. Maybe a browser update broke it?